### PR TITLE
reply invalid requests immediately

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/QuorumRpcReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/QuorumRpcReader.kt
@@ -119,7 +119,12 @@ class QuorumRpcReader(
                 .filter { it.isResolved() } // return nothing if not resolved
                 .map { quorum ->
                     // TODO find actual quorum number
-                    Result(quorum.getResult()!!, quorum.getSignature(), 1, quorum.getResolvedBy().map { it.nodeId() })
+                    Result(
+                        quorum.getResult()!!,
+                        quorum.getSignature(),
+                        1,
+                        quorum.getResolvedBy().map { it.nodeIds().firstOrNull() ?: 0 }
+                    )
                 }
                 .switchIfEmpty(defaultResult)
         }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultUpstream.kt
@@ -26,14 +26,16 @@ import java.util.concurrent.atomic.AtomicReference
 
 abstract class DefaultUpstream(
     private val id: String,
-    private val hash: Byte,
+    hash: Byte,
     defaultLag: Long,
     defaultAvail: UpstreamAvailability,
     private val options: UpstreamsConfig.Options,
     private val role: UpstreamsConfig.UpstreamRole,
     private val targets: CallMethods?,
-    private val node: QuorumForLabels.QuorumItem?
+    node: QuorumForLabels.QuorumItem?
 ) : Upstream {
+
+    private val nodeIds = setOf(hash)
 
     constructor(
         id: String,
@@ -143,7 +145,7 @@ abstract class DefaultUpstream(
         return targets ?: throw IllegalStateException("Methods are not set")
     }
 
-    override fun nodeId(): Byte = hash
+    override fun nodeIds(): Set<Byte> = nodeIds
 
     private val quorumByLabel = node?.let { QuorumForLabels(it) }
         ?: QuorumForLabels(QuorumForLabels.QuorumItem.empty())

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -290,7 +290,7 @@ abstract class Multistream(
         return false
     }
 
-    override fun nodeId(): Byte = 0
+    override fun nodeIds(): Set<Byte> = upstreams.flatMap { it.nodeIds() }.toSet()
 
     fun printStatus() {
         var height: Long? = null

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Selector.kt
@@ -399,7 +399,7 @@ class Selector {
 
     class SameNodeMatcher(private val upstreamHash: Byte) : Matcher {
         override fun matches(up: Upstream): Boolean =
-            up.nodeId() == upstreamHash
+            up.nodeIds().contains(upstreamHash)
 
         override fun describeInternal(): String =
             "upstream node-id=${upstreamHash.toUByte()}"
@@ -413,5 +413,7 @@ class Selector {
             if (other !is SameNodeMatcher) return false
             return other.upstreamHash == upstreamHash
         }
+
+        override fun hashCode(): Int = upstreamHash.toInt()
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Upstream.kt
@@ -41,5 +41,5 @@ interface Upstream {
 
     fun <T : Upstream> cast(selfType: Class<T>): T
 
-    fun nodeId(): Byte
+    fun nodeIds(): Set<Byte>
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/QuorumRpcReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/QuorumRpcReaderSpec.groovy
@@ -40,6 +40,7 @@ class QuorumRpcReaderSpec extends Specification {
         def up = Mock(Upstream) {
             _ * isAvailable() >> true
             _ * getRole() >> UpstreamsConfig.UpstreamRole.PRIMARY
+            _ * nodeIds() >> Collections.singleton(1.byteValue())
             1 * getApi() >> Mock(Reader) {
                 1 * read(new JsonRpcRequest("eth_test", [])) >> Mono.just(JsonRpcResponse.ok("1"))
             }
@@ -137,6 +138,7 @@ class QuorumRpcReaderSpec extends Specification {
         def up = Mock(Upstream) {
             _ * isAvailable() >> true
             _ * getRole() >> UpstreamsConfig.UpstreamRole.PRIMARY
+            _ * nodeIds() >> Collections.singleton(1.byteValue())
             _ * getApi() >> Mock(Reader) {
                 2 * read(new JsonRpcRequest("eth_test", [])) >>> [
                         Mono.just(JsonRpcResponse.ok("null")),
@@ -169,6 +171,7 @@ class QuorumRpcReaderSpec extends Specification {
         def up = Mock(Upstream) {
             _ * isAvailable() >> true
             _ * getRole() >> UpstreamsConfig.UpstreamRole.PRIMARY
+            _ * nodeIds() >> Collections.singleton(1.byteValue())
             _ * getApi() >> Mock(Reader) {
                 2 * read(new JsonRpcRequest("eth_test", [])) >>> [
                         Mono.just(JsonRpcResponse.error(1, "test")),
@@ -200,6 +203,7 @@ class QuorumRpcReaderSpec extends Specification {
         def up = Mock(Upstream) {
             _ * isAvailable() >> true
             _ * getRole() >> UpstreamsConfig.UpstreamRole.PRIMARY
+            _ * nodeIds() >> Collections.singleton(1.byteValue())
             _ * getApi() >> Mock(Reader) {
                 3 * read(new JsonRpcRequest("eth_test", [])) >>> [
                         Mono.just(JsonRpcResponse.ok("null")),

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/SelectorSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/SelectorSpec.groovy
@@ -352,7 +352,7 @@ class SelectorSpec extends Specification {
     def "Matches same nodeId"() {
         setup:
         def up = Mock(Upstream) {
-            nodeId() >> (byte)5
+            nodeIds() >> Collections.singleton((byte)5)
         }
         def matcher = new Selector.SameNodeMatcher((byte)5)
         when:
@@ -364,7 +364,7 @@ class SelectorSpec extends Specification {
     def "Not matches nodeId"() {
         setup:
         def up = Mock(Upstream) {
-            nodeId() >> (byte)5
+            nodeIds() >> Collections.singleton((byte)5)
         }
         def matcher = new Selector.SameNodeMatcher((byte)1)
         when:


### PR DESCRIPTION
We have two method specific matchers: 
- height - added when block hash/height is defined in the request
- nodeId - when getFilter requests executed

both of them can be executed before staring retry logic, and no reason to spend time and retry