### PR TITLE
Serialize WS JSONRpc requests correctly

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnection.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnection.kt
@@ -265,7 +265,7 @@ open class WsConnection(
         val calls = rpcSend
             .asFlux()
             .map {
-                Unpooled.wrappedBuffer(Global.objectMapper.writeValueAsBytes(it))
+                Unpooled.wrappedBuffer(it.toJson())
             }
 
         return outbound.send(


### PR DESCRIPTION
Using toJson method that correctly serializes requests that contain selectors. 
Currently it breaks WS connection.