### PR TITLE
fix managed methods reusing old quorums

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -229,7 +229,7 @@ open class NativeCall(
                 .forMethod(method)
                 .forLabels(Selector.convertToMatcher(request.selector))
 
-            val callQuorum = availableMethods.getQuorumFor(method) // can be null in tests
+            val callQuorum = availableMethods.createQuorumFor(method) // can be null in tests
             callQuorum.init(upstream.getHead())
 
             // for NotLaggingQuorum it makes sense to select compatible upstreams before the call

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/AggregatedCallMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/AggregatedCallMethods.kt
@@ -37,10 +37,10 @@ class AggregatedCallMethods(
     /**
      * Finds first delegate that has Allowed that method and returns its Quorum
      */
-    override fun getQuorumFor(method: String): CallQuorum {
+    override fun createQuorumFor(method: String): CallQuorum {
         return delegates.find {
             it.isCallable(method) || it.isHardcoded(method)
-        }?.getQuorumFor(method) ?: throw IllegalStateException("No executor delegate for $method")
+        }?.createQuorumFor(method) ?: throw IllegalStateException("No executor delegate for $method")
     }
 
     /**

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/CallMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/CallMethods.kt
@@ -24,9 +24,11 @@ import io.emeraldpay.dshackle.quorum.CallQuorum
 interface CallMethods {
 
     /**
+     * For a stateful CallQuorum it _MUST CREATE_ a new instance of each time to avoid using a shared state between different requests
+     *
      * @return CallQuorum configured for the specified method
      */
-    fun getQuorumFor(method: String): CallQuorum
+    fun createQuorumFor(method: String): CallQuorum
 
     /**
      * Check if the method can be called on an upstream. Doesn't include Hardcoded methods

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultBitcoinMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultBitcoinMethods.kt
@@ -59,7 +59,7 @@ class DefaultBitcoinMethods : CallMethods {
     private val allowedMethods =
         (freshMethods + anyResponseMethods + headVerifiedMethods + broadcastMethods).sorted()
 
-    override fun getQuorumFor(method: String): CallQuorum {
+    override fun createQuorumFor(method: String): CallQuorum {
         return when {
             Collections.binarySearch(hardcodedMethods, method) >= 0 -> AlwaysQuorum()
             Collections.binarySearch(anyResponseMethods, method) >= 0 -> NonEmptyQuorum()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
@@ -112,7 +112,7 @@ class DefaultEthereumMethods(
             getChainSpecificMethods(chain)
     }
 
-    override fun getQuorumFor(method: String): CallQuorum {
+    override fun createQuorumFor(method: String): CallQuorum {
         return when {
             filterMethods.contains(method) -> NotLaggingQuorum(1)
             hardcodedMethods.contains(method) -> AlwaysQuorum()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DirectCallMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DirectCallMethods.kt
@@ -28,7 +28,7 @@ open class DirectCallMethods(private val methods: Set<String>) : CallMethods {
     constructor() : this(emptySet())
     constructor(methods: Collection<String>) : this(methods.toSet())
 
-    override fun getQuorumFor(method: String): CallQuorum {
+    override fun createQuorumFor(method: String): CallQuorum {
         return AlwaysQuorum()
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/EthereumCallSelector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/EthereumCallSelector.kt
@@ -42,7 +42,7 @@ class EthereumCallSelector(
             "eth_getBalance",
             "eth_getCode",
             "eth_getTransactionCount",
-            // no "eth_getStorageAt" because it's has different structure, and therefore separate logic
+            // no "eth_getStorageAt" because it has different structure, and therefore separate logic
             "eth_call"
         ).sorted()
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
@@ -132,8 +132,12 @@ class EthereumDirectReader(
      */
     private fun readWithQuorum(request: JsonRpcRequest): Mono<ByteArray> {
         return quorumReaderFactory
-            // we do not use Signer for internal requests because it doesn't make much sense
-            .create(up.getApiSource(Selector.empty), callMethodsFactory.create().getQuorumFor(request.method), null)
+            .create(
+                up.getApiSource(Selector.empty),
+                callMethodsFactory.create().createQuorumFor(request.method),
+                // we do not use Signer for internal requests because it doesn't make much sense
+                null
+            )
             .read(request)
             .map { it.value }
     }

--- a/src/test/groovy/io/emeraldpay/dshackle/startup/ConfiguredUpstreamsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/startup/ConfiguredUpstreamsSpec.groovy
@@ -1,7 +1,6 @@
 package io.emeraldpay.dshackle.startup
 
 import io.emeraldpay.dshackle.FileResolver
-import io.emeraldpay.dshackle.cache.CachesFactory
 import io.emeraldpay.dshackle.config.UpstreamsConfig
 import io.emeraldpay.dshackle.quorum.NonEmptyQuorum
 import io.emeraldpay.dshackle.upstream.CallTargetsHolder
@@ -36,7 +35,7 @@ class ConfiguredUpstreamsSpec extends Specification {
         def act = configurer.buildMethods(upstream, Chain.ETHEREUM)
         then:
         act instanceof ManagedCallMethods
-        act.getQuorumFor("foo_bar") instanceof NonEmptyQuorum
+        act.createQuorumFor("foo_bar") instanceof NonEmptyQuorum
     }
 
     def "Got static response from extra methods"() {

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/MultistreamSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/MultistreamSpec.groovy
@@ -58,9 +58,9 @@ class MultistreamSpec extends Specification {
         act.isCallable("eth_test1")
         act.isCallable("eth_test2")
         act.isCallable("eth_test3")
-        act.getQuorumFor("eth_test1") instanceof AlwaysQuorum
-        act.getQuorumFor("eth_test2") instanceof AlwaysQuorum
-        act.getQuorumFor("eth_test3") instanceof AlwaysQuorum
+        act.createQuorumFor("eth_test1") instanceof AlwaysQuorum
+        act.createQuorumFor("eth_test2") instanceof AlwaysQuorum
+        act.createQuorumFor("eth_test3") instanceof AlwaysQuorum
     }
 
     def "Filter Best Status accepts any input when none available "() {

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/calls/AggregatedCallMethodsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/calls/AggregatedCallMethodsSpec.groovy
@@ -31,11 +31,11 @@ class AggregatedCallMethodsSpec extends Specification {
         def delegate2 = Mock(CallMethods) {
             _ * getSupportedMethods() >> ["eth_test", "foo_bar"]
             1 * isCallable("eth_test") >> true
-            1 * getQuorumFor("eth_test") >> quorum
+            1 * createQuorumFor("eth_test") >> quorum
         }
         def aggregate = new AggregatedCallMethods([delegate1, delegate2])
         when:
-        def act = aggregate.getQuorumFor("eth_test")
+        def act = aggregate.createQuorumFor("eth_test")
         then:
         act == quorum
     }


### PR DESCRIPTION
Dshackle stores values inside quorums which job is to decide the strategy of acquiring results of calling specific methods. All except ManagedCallMethods create new quorums when getQuorumFor is called. This one didn't, so if we defined some methods via config and then call a method with quorum A which succeeds, quorum writes result in its state.
If we call another successful method, no problems occur. However, if we get an error from a node, quorum writes this error in its internal state, but as its cached there is already response from previous successful call.

Thus we NEVER can cache quorums.