### PR TITLE
Fix stuck heads

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/AbstractHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/AbstractHead.kt
@@ -15,8 +15,14 @@
  */
 package io.emeraldpay.dshackle.upstream
 
+import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.data.BlockContainer
 import io.emeraldpay.dshackle.upstream.forkchoice.ForkChoice
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.Tag
 import org.slf4j.LoggerFactory
 import reactor.core.Disposable
 import reactor.core.publisher.Flux
@@ -28,6 +34,7 @@ import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
 abstract class AbstractHead @JvmOverloads constructor(
@@ -48,19 +55,23 @@ abstract class AbstractHead @JvmOverloads constructor(
     private var lastHeadUpdated = 0L
     private val lock = ReentrantLock()
 
+
     init {
+        val state = AtomicBoolean(false)
+        Gauge.builder("stuck_head", state) {
+            if (it.get()) 1.0 else 0.0
+        }
+            .tag("upstream", upstreamId)
+            .tag("class", this.javaClass.simpleName)
+            .register(Metrics.globalRegistry)
+
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
             {
                 val delay = System.currentTimeMillis() - lastHeadUpdated
-                if (delay > awaitHeadTimeoutMs) {
-                    log.warn("No head updates $upstreamId for $delay ms @ ${this.javaClass} - restart")
-                    if (lock.tryLock()) {
-                        try {
-                            start()
-                        } finally {
-                            lock.unlock()
-                        }
-                    }
+                val delayed = delay > awaitHeadTimeoutMs
+                state.set(delayed)
+                if (delayed) {
+                    log.warn("No head updates $upstreamId for $delay ms @ ${this.javaClass}")
                 }
             }, 300, 30, TimeUnit.SECONDS
         )

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -39,13 +39,10 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import java.util.function.Predicate
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
-import kotlin.collections.HashSet
 import kotlin.concurrent.withLock
 
 /**
@@ -149,7 +146,6 @@ abstract class Multistream(
                 setHead(updateHead())
             }
         }
-
 
     /**
      * Get a source for direct APIs

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -333,7 +333,8 @@ abstract class Multistream(
             .filter { it.getStatus() != UpstreamAvailability.OK }
             .joinToString(", ") { it.getId() }
 
-        log.info("State of ${chain.chainCode}: height=${height ?: '?'}, status=[$statuses], lag=[$lag], weak=[$weak]")
+        val instance = System.identityHashCode(this).toString(16)
+        log.info("State of ${chain.chainCode}: height=${height ?: '?'}, status=[$statuses], lag=[$lag], weak=[$weak] ($instance)")
     }
 
     fun test(event: UpstreamChangeEvent): Boolean {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -349,7 +349,7 @@ abstract class Multistream(
             eventLock.withLock {
                 if (event.type == UpstreamChangeEvent.ChangeType.REMOVED) {
                     removeUpstream(event.upstream.getId()).takeIf { it }?.let {
-                        log.error("Upstream ${event.upstream.getId()} with chain $chain has been removed")
+                        log.warn("Upstream ${event.upstream.getId()} with chain $chain has been removed")
                     }
                 } else {
                     if (event.upstream is CachesEnabled) {
@@ -359,7 +359,7 @@ abstract class Multistream(
                         if (!started) {
                             start()
                         }
-                        log.error("Upstream ${event.upstream.getId()} with chain $chain has been added")
+                        log.info("Upstream ${event.upstream.getId()} with chain $chain has been added")
                     }
                 }
             }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/Multistream.kt
@@ -136,10 +136,11 @@ abstract class Multistream(
 
     fun removeUpstream(id: String): Boolean =
         upstreams.removeIf { up ->
-            up.takeIf { up.getId() == id }
-                ?.also { removed[id] = up }
-                ?.let { true }
-                ?: false
+            (up.getId() == id).also {
+                if (it) {
+                    removed[id] = up
+                }
+            }
         }.also {
             if (it) {
                 onUpstreamsUpdated()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/DefaultEthereumHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/DefaultEthereumHead.kt
@@ -61,7 +61,7 @@ open class DefaultEthereumHead(
                 BlockContainer.fromEthereumJson(it.getResult(), upstreamId)
             }
             .onErrorResume { err ->
-                log.debug("Failed to fetch latest block: ${err.message}")
+                log.error("Failed to fetch latest block: ${err.message}")
                 Mono.empty()
             }
     }


### PR DESCRIPTION
**Problem:** if we have a merged head with priority from choice and head having most priority stuck - other heads hove no ability to propagate new heads and the whole multistream head stuck. 
**Fix:** if multistream becomes unavailable we remove it from the multistream and returns back once it ok 
Additionally added metrics for 

- heads have no updates over 60sec `stuck_head`
- current head height for every head `current_head`