### PR TITLE
use g1 gc only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ jib {
         }
     }
     container {
-        jvmFlags = ['-Xms1024m', '-Xmx1024m']
+        jvmFlags = ['-Xms1024m', '-Xmx1024m', '-XX:+UseG1GC']
         mainClass = 'io.emeraldpay.dshackle.StarterKt'
         args = []
         ports = ['2448', '2449', '8545']


### PR DESCRIPTION
We need to use only G1, but in some configuration jvm tries to use Serial GC and it is bad