### PR TITLE
Support for wider scope of providers

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumUpstreamValidator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumUpstreamValidator.kt
@@ -81,6 +81,9 @@ open class EthereumUpstreamValidator(
                         }
                 }
             }
+            .doOnError {
+                log.warn("Error validating ${upstream.getId()}", it)
+            }
             .onErrorReturn(UpstreamAvailability.UNAVAILABLE)
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHead.kt
@@ -71,8 +71,11 @@ class EthereumWsHead(
             .flatMap { block ->
                 // newHeads returns incomplete blocks, i.e. without some fields and without transaction hashes,
                 // so we need to fetch the full block data
-                if (block.difficulty == null || block.transactions == null) {
-                    // TODO do we really need this ?
+                if (block.difficulty == null ||
+                    block.transactions == null ||
+                    block.transactions.isEmpty() ||
+                    block.totalDifficulty == null
+                ) {
                     enhanceRealBlock(block)
                 } else {
                     Mono.just(BlockContainer.from(block))


### PR DESCRIPTION
- we need to read full block in case totalDifficulty is null
- we need to log errors in upstream validation process