### PR TITLE
new upstream change type — updated

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/UpstreamChangeEvent.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/UpstreamChangeEvent.kt
@@ -46,6 +46,11 @@ class UpstreamChangeEvent(
         ADDED,
 
         /**
+         * Some upstream details changed
+         */
+        UPDATED,
+
+        /**
          * Upstream become available after being temporally off
          */
         REVALIDATED,

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/BitcoinGrpcUpstream.kt
@@ -149,9 +149,11 @@ class BitcoinGrpcUpstream(
     override fun stop() {
     }
 
-    override fun update(conf: BlockchainOuterClass.DescribeChain) {
-        upstreamStatus.update(conf)
-        this.capabilities = RemoteCapabilities.extract(conf)
+    override fun update(conf: BlockchainOuterClass.DescribeChain): Boolean {
+        val newCapabilities = RemoteCapabilities.extract(conf)
         conf.status?.let { status -> onStatus(status) }
+        return (upstreamStatus.update(conf) || (newCapabilities != capabilities)).also {
+            capabilities = newCapabilities
+        }
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/EthereumGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/EthereumGrpcUpstream.kt
@@ -131,10 +131,12 @@ open class EthereumGrpcUpstream(
     override fun stop() {
     }
 
-    override fun update(conf: BlockchainOuterClass.DescribeChain) {
-        upstreamStatus.update(conf)
-        capabilities = RemoteCapabilities.extract(conf)
+    override fun update(conf: BlockchainOuterClass.DescribeChain): Boolean {
+        val newCapabilities = RemoteCapabilities.extract(conf)
         conf.status?.let { status -> onStatus(status) }
+        return (upstreamStatus.update(conf) || (newCapabilities != capabilities)).also {
+            capabilities = newCapabilities
+        }
     }
 
     override fun getQuorumByLabel(): QuorumForLabels {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/EthereumPosGrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/EthereumPosGrpcUpstream.kt
@@ -125,10 +125,12 @@ open class EthereumPosGrpcUpstream(
     override fun stop() {
     }
 
-    override fun update(conf: BlockchainOuterClass.DescribeChain) {
-        upstreamStatus.update(conf)
-        capabilities = RemoteCapabilities.extract(conf)
+    override fun update(conf: BlockchainOuterClass.DescribeChain): Boolean {
+        val newCapabilities = RemoteCapabilities.extract(conf)
         conf.status?.let { status -> onStatus(status) }
+        return (upstreamStatus.update(conf) || (newCapabilities != capabilities)).also {
+            capabilities = newCapabilities
+        }
     }
 
     override fun getQuorumByLabel(): QuorumForLabels {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstream.kt
@@ -27,7 +27,7 @@ interface GrpcUpstream : Upstream {
      * Update the configuration of the upstream with the new data.
      * Called on the first creation, and each time a new state received from upstream
      */
-    fun update(conf: BlockchainOuterClass.DescribeChain)
+    fun update(conf: BlockchainOuterClass.DescribeChain): Boolean
 
     fun getBlockchainApi(): ReactorBlockchainGrpc.ReactorBlockchainStub
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstreamStatus.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstreamStatus.kt
@@ -35,7 +35,7 @@ class GrpcUpstreamStatus(
     private val nodes = AtomicReference(QuorumForLabels())
     private var targets: CallMethods? = null
 
-    fun update(conf: BlockchainOuterClass.DescribeChain) {
+    fun update(conf: BlockchainOuterClass.DescribeChain): Boolean {
         val updateLabels = ArrayList<UpstreamsConfig.Labels>()
         val updateNodes = QuorumForLabels()
 
@@ -55,7 +55,9 @@ class GrpcUpstreamStatus(
 
         this.nodes.set(updateNodes)
         this.allLabels.set(Collections.unmodifiableCollection(updateLabels))
+        val changed = conf.supportedMethodsList.toSet() != this.targets?.getSupportedMethods()
         this.targets = DirectCallMethods(conf.supportedMethodsList.toSet())
+        return changed
     }
 
     fun getLabels(): Collection<UpstreamsConfig.Labels> {

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstreamStatusSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcUpstreamStatusSpec.groovy
@@ -65,7 +65,7 @@ class GrpcUpstreamStatusSpec extends Specification {
 
         // more values
         when:
-        status.update(
+        def result = status.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()
                         .addNodes(
                                 BlockchainOuterClass.NodeDetails.newBuilder()
@@ -81,6 +81,7 @@ class GrpcUpstreamStatusSpec extends Specification {
         )
         act = status.getLabels()
         then:
+        !result
         act.toList() == [
                 UpstreamsConfig.Labels.fromMap([test1: "bar", test2: "baz"])
         ]
@@ -109,7 +110,7 @@ class GrpcUpstreamStatusSpec extends Specification {
 
         // replace with new value
         when:
-        status.update(
+        def result = status.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()
                         .addNodes(
                                 BlockchainOuterClass.NodeDetails.newBuilder()
@@ -124,6 +125,7 @@ class GrpcUpstreamStatusSpec extends Specification {
         )
         act = status.getLabels()
         then:
+        !result
         act.toList() == [
                 UpstreamsConfig.Labels.fromMap([test: "bar", fix: "value"])
         ]
@@ -202,7 +204,7 @@ class GrpcUpstreamStatusSpec extends Specification {
         setup:
         def status = new GrpcUpstreamStatus(null)
         when:
-        status.update(
+        def result = status.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()
                         .addAllSupportedMethods([
                                 "test_1",
@@ -212,7 +214,35 @@ class GrpcUpstreamStatusSpec extends Specification {
         )
         def act = status.getCallMethods()
         then:
+        result
         act.supportedMethods == ["test_1", "test_2"].toSet()
+        act instanceof DirectCallMethods
+    }
+
+    def "Updates with new methods"() {
+        setup:
+        def status = new GrpcUpstreamStatus(null)
+        status.update(
+                BlockchainOuterClass.DescribeChain.newBuilder()
+                        .addAllSupportedMethods([
+                                "test_1",
+                                "test_2"
+                        ])
+                        .build()
+        )
+        when:
+        def result = status.update(
+                BlockchainOuterClass.DescribeChain.newBuilder()
+                        .addAllSupportedMethods([
+                                "test_1",
+                                "test_2",
+                                "test_3"
+                        ])
+                        .build())
+        def act = status.getCallMethods()
+        then:
+        result
+        act.supportedMethods == ["test_1", "test_2", "test_3"].toSet()
         act instanceof DirectCallMethods
     }
 }


### PR DESCRIPTION
Currently if upstream available methods change, we update them for that upstream.
However, we won't update Multistream available methods. Probably this is the aftereffect of not removing unavailable GRPC upstreams.

This PR changes that: introducing new UPDATED event. 