### PR TITLE
Turn off caches for main, fix cache not enrichment blocks

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
@@ -39,7 +39,7 @@ open class BlocksMemCache(
     }
 
     open fun add(block: BlockContainer) {
-        if (!block.full) {
+        if (!block.enriched) {
             return
         }
         mapping.put(block.hash, block)

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
@@ -39,7 +39,7 @@ open class BlocksMemCache(
     }
 
     open fun add(block: BlockContainer) {
-        if (!block.isEnriched()) {
+        if (!block.full) {
             return
         }
         mapping.put(block.hash, block)

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/BlocksMemCache.kt
@@ -39,6 +39,9 @@ open class BlocksMemCache(
     }
 
     open fun add(block: BlockContainer) {
+        if (!block.isEnriched()) {
+            return
+        }
         mapping.put(block.hash, block)
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/Caches.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/Caches.kt
@@ -207,7 +207,7 @@ open class Caches(
         return receiptByHash
     }
 
-    fun getLastHeightByHash(): Reader<BlockId, Long> {
+    open fun getLastHeightByHash(): Reader<BlockId, Long> {
         return memHeightByHash
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/Caches.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/Caches.kt
@@ -39,7 +39,8 @@ open class Caches(
     private val redisBlocksByHash: BlocksRedisCache?,
     private val redisTxsByHash: TxRedisCache?,
     private val redisReceipts: ReceiptRedisCache?,
-    private val redisHeightByHashCache: HeightByHashRedisCache?
+    private val redisHeightByHashCache: HeightByHashRedisCache?,
+    private val cacheEnabled: Boolean
 ) {
 
     companion object {
@@ -89,6 +90,9 @@ open class Caches(
     }
 
     open fun cacheReceipt(tag: Tag, data: DefaultContainer<TransactionReceiptJson>) {
+        if (!cacheEnabled) {
+            return
+        }
         val currentHeight = head?.getCurrentHeight()
         if (currentHeight != null && data.height != null && memReceipts.acceptsRecentBlocks(currentHeight - data.height)) {
             memReceipts.add(data).subscribe()
@@ -98,6 +102,9 @@ open class Caches(
     }
 
     fun cache(tag: Tag, tx: TxContainer) {
+        if (!cacheEnabled) {
+            return
+        }
         // do not cache transactions that are not in a block yet
         if (tx.blockId == null) {
             return
@@ -110,6 +117,9 @@ open class Caches(
     }
 
     fun cache(tag: Tag, block: BlockContainer) {
+        if (!cacheEnabled) {
+            return
+        }
         val job = ArrayList<Mono<Void>>()
 
         redisHeightByHashCache?.add(block)?.let(job::add)
@@ -129,7 +139,6 @@ open class Caches(
                 blockOnlyContainer = block
             }
             memoizeBlock(blockOnlyContainer)
-            memBlocksByHash.add(blockOnlyContainer)
             redisBlocksByHash?.add(blockOnlyContainer)?.let(job::add)
 
             // now cache only transactions
@@ -227,6 +236,7 @@ open class Caches(
         private var redisTxsByHash: TxRedisCache? = null
         private var redisReceiptCache: ReceiptRedisCache? = null
         private var redisHeightByHashCache: HeightByHashRedisCache? = null
+        private var cacheEnabled: Boolean = true
 
         fun setBlockByHash(cache: BlocksMemCache): Builder {
             blocksByHash = cache
@@ -268,6 +278,11 @@ open class Caches(
             return this
         }
 
+        fun setCacheEnabled(cacheEnabled: Boolean): Builder {
+            this.cacheEnabled = cacheEnabled
+            return this
+        }
+
         fun build(): Caches {
             if (blocksByHash == null) {
                 blocksByHash = BlocksMemCache()
@@ -283,7 +298,7 @@ open class Caches(
             }
             return Caches(
                 blocksByHash!!, blocksByHeight!!, txsByHash!!, receipts!!,
-                redisBlocksByHash, redisTxsByHash, redisReceiptCache, redisHeightByHashCache
+                redisBlocksByHash, redisTxsByHash, redisReceiptCache, redisHeightByHashCache, cacheEnabled
             )
         }
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/CachesFactory.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/CachesFactory.kt
@@ -97,6 +97,7 @@ open class CachesFactory(
             caches.setReceipts(ReceiptRedisCache(redis.reactive(), chain))
             caches.setHeightByHash(HeightByHashRedisCache(redis.reactive(), chain))
         }
+        caches.setCacheEnabled(cacheConfig.requestsCacheEnabled)
         return caches.build()
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/cache/HeightByHashMemCache.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/cache/HeightByHashMemCache.kt
@@ -22,7 +22,7 @@ import io.emeraldpay.dshackle.reader.Reader
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
-class HeightByHashMemCache(
+open class HeightByHashMemCache(
     maxSize: Int = 256
 ) : Reader<BlockId, Long> {
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
@@ -93,6 +93,8 @@ class BlockContainer(
         return BlockContainer(height, hash, difficulty, timestamp, full, json, parsed, transactions, nodeRating)
     }
 
+    fun isEnriched(): Boolean = transactions.isNotEmpty()
+
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + height.hashCode()

--- a/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
@@ -34,6 +34,7 @@ class BlockContainer(
     val nodeRating: Int = 0,
     val upstreamId: String = ""
 ) : SourceContainer(json, parsed) {
+    val enriched: Boolean = transactions.isNotEmpty()
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/data/BlockContainer.kt
@@ -93,8 +93,6 @@ class BlockContainer(
         return BlockContainer(height, hash, difficulty, timestamp, full, json, parsed, transactions, nodeRating)
     }
 
-    fun isEnriched(): Boolean = transactions.isNotEmpty()
-
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + height.hashCode()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/EthereumCallSelector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/EthereumCallSelector.kt
@@ -164,10 +164,10 @@ class EthereumCallSelector(
 
     private fun blockByHashFromCache(blockHash: String): Mono<Selector.Matcher> {
         return try {
-            caches.getBlocksByHash()
+            caches.getLastHeightByHash()
                 .read(BlockId.from(blockHash))
                 .onErrorResume { Mono.empty() }
-                .map { Selector.HeightMatcher(it.height) }
+                .map { Selector.HeightMatcher(it) }
         } catch (e: DecoderException) {
             log.warn("Invalid blockHash: $blockHash")
             Mono.empty()

--- a/src/test/groovy/io/emeraldpay/dshackle/cache/BlockByHeightSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/cache/BlockByHeightSpec.groovy
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.data.BlockContainer
 import io.emeraldpay.etherjar.domain.BlockHash
+import io.emeraldpay.etherjar.domain.TransactionId
 import io.emeraldpay.etherjar.rpc.json.BlockJson
+import io.emeraldpay.etherjar.rpc.json.TransactionJson
 import io.emeraldpay.etherjar.rpc.json.TransactionRefJson
 import spock.lang.Specification
 
@@ -39,12 +41,14 @@ class BlockByHeightSpec extends Specification {
         def heights = new HeightCache()
 
         def block = new BlockJson<TransactionRefJson>()
+        def tx = new TransactionJson()
+        tx.hash = TransactionId.from(hash1)
         block.number = 100
         block.hash = BlockHash.from(hash1)
         block.totalDifficulty = BigInteger.ONE
         block.timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
         block.uncles = []
-        block.transactions = []
+        block.transactions = List.of(tx)
 
         BlockContainer.from(block).with {
             blocks.add(it)
@@ -65,12 +69,14 @@ class BlockByHeightSpec extends Specification {
         def heights = new HeightCache()
 
         def block1 = new BlockJson<TransactionRefJson>()
+        def tx = new TransactionJson()
+        tx.hash = TransactionId.from(hash1)
         block1.number = 100
         block1.hash = BlockHash.from(hash1)
         block1.totalDifficulty = BigInteger.ONE
         block1.timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
         block1.uncles = []
-        block1.transactions = []
+        block1.transactions = List.of(tx)
 
         def block2 = new BlockJson<TransactionRefJson>()
         block2.number = 101
@@ -78,7 +84,7 @@ class BlockByHeightSpec extends Specification {
         block2.totalDifficulty = BigInteger.ONE
         block2.timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
         block2.uncles = []
-        block2.transactions = []
+        block2.transactions = List.of(tx)
 
 
         BlockContainer.from(block1).with {
@@ -109,12 +115,14 @@ class BlockByHeightSpec extends Specification {
         def heights = new HeightCache()
 
         def block1 = new BlockJson<TransactionRefJson>()
+        def tx = new TransactionJson()
+        tx.hash = TransactionId.from(hash1)
         block1.number = 100
         block1.hash = BlockHash.from(hash1)
         block1.totalDifficulty = BigInteger.ONE
         block1.timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
         block1.uncles = []
-        block1.transactions = []
+        block1.transactions = List.of(tx)
 
         def block2 = new BlockJson<TransactionRefJson>()
         block2.number = 100
@@ -122,7 +130,7 @@ class BlockByHeightSpec extends Specification {
         block2.totalDifficulty = BigInteger.ONE
         block2.timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
         block2.uncles = []
-        block2.transactions = []
+        block2.transactions = List.of(tx)
 
         BlockContainer.from(block1).with {
             blocks.add(it)


### PR DESCRIPTION
- turn off cache enrichment for main - previously it was enriched but not use
- fix cache not full blocks - blocks from newHeads sub are not cached to `<BlockId, BlockContainer>` but only in hash -> height and height -> hash
- removed extra cache for requested tag
- change cache for height matcher by hash