### PR TITLE
Resubscribe to newHeads immediately after reconnection

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/WebsocketConnectionStatesHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/WebsocketConnectionStatesHandler.kt
@@ -1,0 +1,37 @@
+package io.emeraldpay.dshackle.upstream
+
+import io.emeraldpay.dshackle.upstream.ethereum.WsConnection
+import io.emeraldpay.dshackle.upstream.ethereum.WsSubscriptions
+import reactor.core.publisher.Flux
+
+class WebsocketConnectionStatesHandler(
+    private val wsSubscriptions: WsSubscriptions,
+    private val onConnected: () -> Unit
+) {
+    private var connectionId: String? = null
+    private var tryResubscribe = false
+
+    init {
+        wsSubscriptions.connectionInfoFlux()
+            .subscribe {
+                if (it.connectionId == connectionId && it.connectionState == WsConnection.ConnectionState.DISCONNECTED) {
+                    connectionId = null
+                    if (tryResubscribe) {
+                        tryResubscribe = false
+                    }
+                } else if (connectionId == null && it.connectionState == WsConnection.ConnectionState.CONNECTED) {
+                    if (!tryResubscribe) {
+                        tryResubscribe = true
+                        onConnected()
+                    }
+                }
+            }
+    }
+
+    fun subscribe(method: String): Flux<ByteArray> =
+        wsSubscriptions.subscribe(method)
+            .also {
+                connectionId = it.connectionId
+                tryResubscribe = false
+            }.data
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnection.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnection.kt
@@ -25,7 +25,18 @@ interface WsConnection : AutoCloseable {
 
     val isConnected: Boolean
 
+    fun connectionId(): String
     fun getSubscribeResponses(): Flux<JsonRpcWsMessage>
     fun callRpc(originalRequest: JsonRpcRequest): Mono<JsonRpcResponse>
     fun connect()
+    fun connectionInfoFlux(): Flux<ConnectionInfo>
+
+    data class ConnectionInfo(
+        val connectionId: String,
+        val connectionState: ConnectionState
+    )
+
+    enum class ConnectionState {
+        CONNECTED, DISCONNECTED
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPool.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPool.kt
@@ -20,6 +20,9 @@ import io.emeraldpay.dshackle.upstream.DefaultUpstream
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import org.springframework.util.backoff.BackOffExecution
 import org.springframework.util.backoff.ExponentialBackOff
+import reactor.core.Disposable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Sinks
 import java.time.Duration
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -50,6 +53,8 @@ class WsConnectionMultiPool(
     private var adjustLock = ReentrantReadWriteLock()
     private val index = AtomicInteger(0)
     private var connIndex = 0
+    private val connectionInfo = Sinks.many().unicast().onBackpressureError<WsConnection.ConnectionInfo>()
+    private val connectionSubscriptionMap = mutableMapOf<String, Disposable>()
 
     var scheduler: ScheduledExecutorService = Global.control
 
@@ -73,8 +78,13 @@ class WsConnectionMultiPool(
         return next
     }
 
+    override fun connectionInfoFlux(): Flux<WsConnection.ConnectionInfo> =
+        connectionInfo.asFlux()
+
     override fun close() {
         adjustLock.write {
+            connectionSubscriptionMap.values.forEach { it.dispose() }
+            connectionSubscriptionMap.clear()
             current.forEach { it.close() }
             current.clear()
         }
@@ -106,6 +116,9 @@ class WsConnectionMultiPool(
                             }
                         }.also {
                             it.connect()
+                            connectionSubscriptionMap[it.connectionId()] = it.connectionInfoFlux().subscribe { info ->
+                                connectionInfo.emitNext(info) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
+                            }
                         }
                     )
                     SCHEDULE_GROW
@@ -116,6 +129,7 @@ class WsConnectionMultiPool(
                 current.removeIf {
                     if (!it.isConnected) {
                         // DO NOT FORGET to close the connection, otherwise it would keep reconnecting but unused
+                        connectionSubscriptionMap.remove(it.connectionId())?.dispose()
                         it.close()
                         true
                     } else {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPool.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPool.kt
@@ -53,7 +53,7 @@ class WsConnectionMultiPool(
     private var adjustLock = ReentrantReadWriteLock()
     private val index = AtomicInteger(0)
     private var connIndex = 0
-    private val connectionInfo = Sinks.many().unicast().onBackpressureError<WsConnection.ConnectionInfo>()
+    private val connectionInfo = Sinks.many().multicast().directBestEffort<WsConnection.ConnectionInfo>()
     private val connectionSubscriptionMap = mutableMapOf<String, Disposable>()
 
     var scheduler: ScheduledExecutorService = Global.control

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionPool.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionPool.kt
@@ -15,7 +15,10 @@
  */
 package io.emeraldpay.dshackle.upstream.ethereum
 
+import reactor.core.publisher.Flux
+
 interface WsConnectionPool : AutoCloseable {
     fun connect()
     fun getConnection(): WsConnection
+    fun connectionInfoFlux(): Flux<WsConnection.ConnectionInfo>
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionSinglePool.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionSinglePool.kt
@@ -17,6 +17,7 @@ package io.emeraldpay.dshackle.upstream.ethereum
 
 import io.emeraldpay.dshackle.upstream.DefaultUpstream
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
+import reactor.core.publisher.Flux
 
 class WsConnectionSinglePool(
     ethereumWsConnectionFactory: EthereumWsConnectionFactory,
@@ -35,6 +36,9 @@ class WsConnectionSinglePool(
     override fun getConnection(): WsConnection {
         return connection
     }
+
+    override fun connectionInfoFlux(): Flux<WsConnection.ConnectionInfo> =
+        connection.connectionInfoFlux()
 
     override fun close() {
         connection.close()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsSubscriptions.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsSubscriptions.kt
@@ -37,5 +37,12 @@ interface WsSubscriptions {
     /**
      * Subscribe on remote
      */
-    fun subscribe(method: String): Flux<ByteArray>
+    fun subscribe(method: String): SubscribeData
+
+    fun connectionInfoFlux(): Flux<WsConnection.ConnectionInfo>
+
+    data class SubscribeData(
+        val data: Flux<ByteArray>,
+        val connectionId: String
+    )
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/WebsocketPendingTxes.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/WebsocketPendingTxes.kt
@@ -34,6 +34,7 @@ class WebsocketPendingTxes(
 
     override fun createConnection(): Flux<TransactionId> {
         return wsSubscriptions.subscribe(EthereumEgressSubscription.METHOD_PENDING_TXES)
+            .data
             .timeout(Duration.ofSeconds(60), Mono.empty())
             .map {
                 // comes as a JS string, i.e., within quotes

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPoolSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionMultiPoolSpec.groovy
@@ -16,6 +16,7 @@
 package io.emeraldpay.dshackle.upstream.ethereum
 
 import io.emeraldpay.dshackle.upstream.DefaultUpstream
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 import java.util.concurrent.ScheduledExecutorService
@@ -24,7 +25,9 @@ class WsConnectionMultiPoolSpec extends Specification {
 
     def "create connection when less than required"() {
         setup:
-        def conn = Mock(WsConnection)
+        def conn = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
         def up = Mock(DefaultUpstream)
         def factory = Mock(EthereumWsConnectionFactory)
         def pool = new WsConnectionMultiPool(factory, up, 3)
@@ -40,9 +43,15 @@ class WsConnectionMultiPoolSpec extends Specification {
 
     def "create connection until target"() {
         setup:
-        def conn1 = Mock(WsConnection)
-        def conn2 = Mock(WsConnection)
-        def conn3 = Mock(WsConnection)
+        def conn1 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
+        def conn2 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
+        def conn3 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
         def up = Mock(DefaultUpstream)
         def factory = Mock(EthereumWsConnectionFactory)
         def pool = new WsConnectionMultiPool(factory, up, 3)
@@ -84,10 +93,18 @@ class WsConnectionMultiPoolSpec extends Specification {
 
     def "recreate connection after failure"() {
         setup:
-        def conn1 = Mock(WsConnection)
-        def conn2 = Mock(WsConnection)
-        def conn3 = Mock(WsConnection)
-        def conn4 = Mock(WsConnection)
+        def conn1 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
+        def conn2 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
+        def conn3 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
+        def conn4 = Mock(WsConnection) {
+            1 * it.connectionInfoFlux() >> Flux.empty()
+        }
         def up = Mock(DefaultUpstream)
         def factory = Mock(EthereumWsConnectionFactory)
         def pool = new WsConnectionMultiPool(factory, up, 3)

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsSubscriptionsImplSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsSubscriptionsImplSpec.groovy
@@ -36,7 +36,9 @@ class WsSubscriptionsImplSpec extends Specification {
                 ]
         )
 
-        def conn = Mock(WsConnection)
+        def conn = Mock(WsConnection) {
+            1 * it.connectionId() >> "id"
+        }
         def pool = Mock(WsConnectionPool) {
             getConnection() >> conn
         }
@@ -44,6 +46,7 @@ class WsSubscriptionsImplSpec extends Specification {
 
         when:
         def act = ws.subscribe("foo_bar")
+            .data
             .map { new String(it) }
             .take(3)
             .collectList().block(Duration.ofSeconds(1))
@@ -71,7 +74,9 @@ class WsSubscriptionsImplSpec extends Specification {
                 ]
         )
 
-        def conn = Mock(WsConnection)
+        def conn = Mock(WsConnection) {
+            1 * it.connectionId() >> "id"
+        }
         def pool = Mock(WsConnectionPool) {
             getConnection() >> conn
         }
@@ -79,6 +84,7 @@ class WsSubscriptionsImplSpec extends Specification {
 
         when:
         def act = ws.subscribe("foo_bar")
+                .data
                 .map { new String(it) }
                 .take(3)
                 .collectList().block(Duration.ofSeconds(1))

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/WebsocketPendingTxesSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/WebsocketPendingTxesSpec.groovy
@@ -40,7 +40,9 @@ class WebsocketPendingTxesSpec extends Specification {
                 .collectList().block(Duration.ofSeconds(1))
 
         then:
-        1 * ws.subscribe("newPendingTransactions") >> Flux.fromIterable(responses)
+        1 * ws.subscribe("newPendingTransactions") >> new WsSubscriptions.SubscribeData(
+                Flux.fromIterable(responses), "id"
+        )
         txes.collect {it.toHex() } == [
                 "0xa61bab14fc9720ea8725622688c2f964666d7c2afdae38af7dad53f12f242d5c",
                 "0x911548eb0f3bf353a54e03a3506c7c3e747470d6c201f03babbc07ff6e14cd6e",


### PR DESCRIPTION
Add connectionInfo flux with ws states - `CONNECTED` and `DISCONNECTED`. Subscribe to it in `EthereumWsHead` and as soon as `CONNECTED` event is come try to restart and resubscribe to newHeads.