### PR TITLE
Threadpool tuning part 2

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
@@ -388,6 +388,7 @@ open class ConfiguredUpstreams(
                 id, chain,
                 endpoint.url,
                 endpoint.origin ?: URI("http://localhost"),
+                headScheduler
             ).apply {
                 config = endpoint
                 basicAuth = endpoint.basicAuth

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscription.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscription.kt
@@ -10,9 +10,11 @@ import io.emeraldpay.etherjar.domain.Address
 import io.emeraldpay.etherjar.hex.Hex32
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Scheduler
 
 open class EthereumEgressSubscription(
     val upstream: EthereumLikeMultistream,
+    val scheduler: Scheduler,
     val pendingTxesSource: PendingTxesSource?
 ) : EgressSubscription {
 
@@ -37,8 +39,8 @@ open class EthereumEgressSubscription(
         }
     }
 
-    private val newHeads = ConnectNewHeads(upstream)
-    open val logs = ConnectLogs(upstream)
+    private val newHeads = ConnectNewHeads(upstream, scheduler)
+    open val logs = ConnectLogs(upstream, scheduler)
     private val syncing = ConnectSyncing(upstream)
 
     override fun getAvailableTopics() = availableTopics

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumMultistream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumMultistream.kt
@@ -63,7 +63,7 @@ open class EthereumMultistream(
         ConcurrentReferenceHashMap(16, ConcurrentReferenceHashMap.ReferenceType.WEAK)
 
     private val reader: EthereumCachingReader = EthereumCachingReader(this, this.caches, getMethodsFactory(), tracer)
-    private var subscribe = EthereumEgressSubscription(this, NoPendingTxes())
+    private var subscribe = EthereumEgressSubscription(this, headScheduler, NoPendingTxes())
 
     private val supportsEIP1559 = when (chain) {
         Chain.ETHEREUM, Chain.TESTNET_ROPSTEN,
@@ -102,7 +102,7 @@ open class EthereumMultistream(
                     AggregatedPendingTxes(it)
                 }
             }
-        subscribe = EthereumEgressSubscription(this, pendingTxes)
+        subscribe = EthereumEgressSubscription(this, headScheduler, pendingTxes)
     }
 
     override fun start() {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsConnectionFactory.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsConnectionFactory.kt
@@ -8,6 +8,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
+import reactor.core.scheduler.Scheduler
 import java.net.URI
 
 open class EthereumWsConnectionFactory(
@@ -15,6 +16,7 @@ open class EthereumWsConnectionFactory(
     private val chain: Chain,
     private val uri: URI,
     private val origin: URI,
+    private val scheduler: Scheduler
 ) {
 
     var basicAuth: AuthConfig.ClientBasicAuth? = null
@@ -42,7 +44,7 @@ open class EthereumWsConnectionFactory(
     }
 
     open fun createWsConnection(connIndex: Int = 0, onDisconnect: () -> Unit): WsConnection =
-        WsConnectionImpl(uri, origin, basicAuth, metrics(connIndex), onDisconnect).also { ws ->
+        WsConnectionImpl(uri, origin, basicAuth, metrics(connIndex), onDisconnect, scheduler).also { ws ->
             config?.frameSize?.let {
                 ws.frameSize = it
             }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHead.kt
@@ -33,7 +33,6 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
 import reactor.core.scheduler.Scheduler
-import reactor.core.scheduler.Schedulers
 import reactor.retry.Repeat
 import java.time.Duration
 
@@ -45,7 +44,7 @@ class EthereumWsHead(
     private val wsSubscriptions: WsSubscriptions,
     private val skipEnhance: Boolean,
     private val wsConnectionResubscribeScheduler: Scheduler,
-    headScheduler: Scheduler,
+    private val headScheduler: Scheduler,
 ) : DefaultEthereumHead(upstreamId, forkChoice, blockValidator, headScheduler), Lifecycle {
 
     private var connectionId: String? = null
@@ -119,7 +118,7 @@ class EthereumWsHead(
                     }
                     .flatMap(JsonRpcResponse::requireResult)
                     .map { BlockContainer.fromEthereumJson(it, upstreamId) }
-                    .subscribeOn(Schedulers.boundedElastic())
+                    .subscribeOn(headScheduler)
                     .timeout(Defaults.timeoutInternal, Mono.empty())
             }.repeatWhenEmpty { n ->
                 Repeat.times<Any>(5)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
@@ -44,7 +44,7 @@ import reactor.core.Disposable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
-import reactor.core.scheduler.Schedulers
+import reactor.core.scheduler.Scheduler
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.WebsocketClientSpec
 import reactor.netty.http.websocket.WebsocketInbound
@@ -67,7 +67,8 @@ open class WsConnectionImpl(
     private val origin: URI,
     private val basicAuth: AuthConfig.ClientBasicAuth?,
     private val rpcMetrics: RpcMetrics?,
-    private val onDisconnect: () -> Unit
+    private val onDisconnect: () -> Unit,
+    private val scheduler: Scheduler
 ) : AutoCloseable, WsConnection, Cloneable {
 
     companion object {
@@ -292,8 +293,8 @@ open class WsConnectionImpl(
 
         return outbound.send(
             Flux.merge(
-                calls.subscribeOn(Schedulers.boundedElastic()),
-                consumer.then(Mono.empty<ByteBuf>()).subscribeOn(Schedulers.boundedElastic())
+                calls.subscribeOn(scheduler),
+                consumer.then(Mono.empty<ByteBuf>()).subscribeOn(scheduler)
             )
         )
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogs.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogs.kt
@@ -22,8 +22,8 @@ import io.emeraldpay.dshackle.upstream.ethereum.subscribe.json.LogMessage
 import io.emeraldpay.etherjar.domain.Address
 import io.emeraldpay.etherjar.hex.Hex32
 import io.emeraldpay.etherjar.hex.HexDataComparator
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Scheduler
 import java.util.function.Function
 
 open class ConnectLogs(
@@ -32,14 +32,11 @@ open class ConnectLogs(
 ) {
 
     companion object {
-        private val log = LoggerFactory.getLogger(ConnectLogs::class.java)
-
         private val ADDR_COMPARATOR = HexDataComparator()
         private val TOPIC_COMPARATOR = HexDataComparator()
     }
 
-    constructor(upstream: EthereumLikeMultistream) : this(upstream, ConnectBlockUpdates(upstream))
-
+    constructor(upstream: EthereumLikeMultistream, scheduler: Scheduler) : this(upstream, ConnectBlockUpdates(upstream, scheduler))
     private val produceLogs = ProduceLogs(upstream)
 
     fun start(matcher: Selector.Matcher): Flux<LogMessage> {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectSyncing.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectSyncing.kt
@@ -19,7 +19,6 @@ import io.emeraldpay.dshackle.upstream.Selector
 import io.emeraldpay.dshackle.upstream.SubscriptionConnect
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import io.emeraldpay.dshackle.upstream.ethereum.EthereumLikeMultistream
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import java.time.Duration
 import java.util.concurrent.locks.ReentrantLock
@@ -28,10 +27,6 @@ import kotlin.concurrent.withLock
 class ConnectSyncing(
     private val upstream: EthereumLikeMultistream
 ) : SubscriptionConnect<Boolean> {
-
-    companion object {
-        private val log = LoggerFactory.getLogger(ConnectSyncing::class.java)
-    }
 
     private var connected: Flux<Boolean>? = null
     private val connectLock = ReentrantLock()

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum_pos/EthereumPosMultiStream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum_pos/EthereumPosMultiStream.kt
@@ -58,7 +58,7 @@ open class EthereumPosMultiStream(
     )
 
     private val reader: EthereumCachingReader = EthereumCachingReader(this, this.caches, getMethodsFactory(), tracer)
-    private var subscribe = EthereumEgressSubscription(this, NoPendingTxes())
+    private var subscribe = EthereumEgressSubscription(this, headScheduler, NoPendingTxes())
     private val feeEstimation = EthereumPriorityFees(this, reader, 256)
     private val filteredHeads: MutableMap<String, Head> =
         ConcurrentReferenceHashMap(16, ConcurrentReferenceHashMap.ReferenceType.WEAK)
@@ -198,6 +198,6 @@ open class EthereumPosMultiStream(
                     AggregatedPendingTxes(it)
                 }
             }
-        subscribe = EthereumEgressSubscription(this, pendingTxes)
+        subscribe = EthereumEgressSubscription(this, headScheduler, pendingTxes)
     }
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/rpc/TrackEthereumTxSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/rpc/TrackEthereumTxSpec.groovy
@@ -102,7 +102,7 @@ class TrackEthereumTxSpec extends Specification {
         def apiMock = TestingCommons.api()
         def upstreamMock = TestingCommons.upstream(apiMock)
         MultistreamHolder upstreams = new MultistreamHolderMock(Chain.ETHEREUM, upstreamMock)
-        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.boundedElastic())
+        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.parallel())
 
         apiMock.answer("eth_getTransactionByHash", [txId], txJson)
         apiMock.answer("eth_getBlockByHash", [blockJson.hash.toHex(), false], blockJson)
@@ -195,7 +195,7 @@ class TrackEthereumTxSpec extends Specification {
         def apiMock = TestingCommons.api()
         def upstreamMock = TestingCommons.upstream(apiMock)
         MultistreamHolder upstreams = new MultistreamHolderMock(Chain.ETHEREUM, upstreamMock)
-        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.boundedElastic())
+        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.parallel())
 
         def tx = new TrackEthereumTx.TxDetails(Chain.ETHEREUM, Instant.now(), TransactionId.from(txId), 6)
         def block = new BlockContainer(
@@ -217,7 +217,7 @@ class TrackEthereumTxSpec extends Specification {
         def apiMock = TestingCommons.api()
         def upstreamMock = TestingCommons.upstream(apiMock)
         MultistreamHolder upstreams = new MultistreamHolderMock(Chain.ETHEREUM, upstreamMock)
-        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.boundedElastic())
+        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.parallel())
 
         def tx = new TrackEthereumTx.TxDetails(Chain.ETHEREUM, Instant.now(), TransactionId.from(txId), 6)
         def block = new BlockContainer(
@@ -296,7 +296,7 @@ class TrackEthereumTxSpec extends Specification {
         }
         MultistreamHolder upstreams = new MultistreamHolderMock(Chain.ETHEREUM, multi)
 
-        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.boundedElastic())
+        TrackEthereumTx trackTx = new TrackEthereumTx(upstreams, Schedulers.parallel())
 
         apiMock.answerOnce("eth_getTransactionByHash", [txId], null)
         apiMock.answerOnce("eth_getTransactionByHash", [txId], txJsonBroadcasted)

--- a/src/test/groovy/io/emeraldpay/dshackle/startup/ConfiguredUpstreamsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/startup/ConfiguredUpstreamsSpec.groovy
@@ -30,9 +30,9 @@ class ConfiguredUpstreamsSpec extends Specification {
                 Executors.newFixedThreadPool(1),
                 ChainsConfig.default(),
                 GrpcTracing.create(Tracing.newBuilder().build()),
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
                 null,
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
         )
         def methods = new UpstreamsConfig.Methods(
                 [
@@ -62,9 +62,9 @@ class ConfiguredUpstreamsSpec extends Specification {
                 Executors.newFixedThreadPool(1),
                 ChainsConfig.default(),
                 GrpcTracing.create(Tracing.newBuilder().build()),
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
                 null,
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
         )
         def methods = new UpstreamsConfig.Methods(
                 [
@@ -93,9 +93,9 @@ class ConfiguredUpstreamsSpec extends Specification {
                 Executors.newFixedThreadPool(1),
                 ChainsConfig.default(),
                 GrpcTracing.create(Tracing.newBuilder().build()),
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
                 null,
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
         )
         expect:
         configurer.getHash(node, src) == expected
@@ -119,9 +119,9 @@ class ConfiguredUpstreamsSpec extends Specification {
                 Executors.newFixedThreadPool(1),
                 ChainsConfig.default(),
                 GrpcTracing.create(Tracing.newBuilder().build()),
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
                 null,
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
         )
         when:
         def h1 = configurer.getHash(null, "hohoho")
@@ -150,9 +150,9 @@ class ConfiguredUpstreamsSpec extends Specification {
                 Executors.newFixedThreadPool(1),
                 ChainsConfig.default(),
                 GrpcTracing.create(Tracing.newBuilder().build()),
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
                 null,
-                Schedulers.boundedElastic(),
+                Schedulers.parallel(),
         )
         def methodsGroup = new UpstreamsConfig.MethodGroups(
                 ["filter"] as Set,

--- a/src/test/groovy/io/emeraldpay/dshackle/test/MultistreamHolderMock.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/MultistreamHolderMock.groovy
@@ -49,7 +49,7 @@ class MultistreamHolderMock implements MultistreamHolder {
                 } else if (up instanceof EthereumPosRpcUpstream) {
                     upstreams[chain] = new EthereumPosMultiStream(
                             chain, [up as EthereumPosRpcUpstream], Caches.default(),
-                            Schedulers.boundedElastic(), TestingCommons.tracerMock()
+                            Schedulers.parallel(), TestingCommons.tracerMock()
                     )
                 } else {
                     throw new IllegalArgumentException("Unsupported upstream type ${up.class}")
@@ -98,7 +98,7 @@ class MultistreamHolderMock implements MultistreamHolder {
         Head customHead = null
 
         EthereumMultistreamMock(@NotNull Chain chain, @NotNull List<EthereumPosRpcUpstream> upstreams, @NotNull Caches caches) {
-            super(chain, upstreams, caches, Schedulers.boundedElastic(), new BraveTracer(null, null, null))
+            super(chain, upstreams, caches, Schedulers.parallel(), new BraveTracer(null, null, null))
         }
 
         EthereumMultistreamMock(@NotNull Chain chain, @NotNull List<EthereumPosRpcUpstream> upstreams) {

--- a/src/test/groovy/io/emeraldpay/dshackle/test/TestingCommons.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/TestingCommons.groovy
@@ -88,7 +88,7 @@ class TestingCommons {
     }
 
     static Multistream multistream(EthereumPosRpcUpstreamMock up) {
-        return new EthereumPosMultiStream(Chain.ETHEREUM, [up], Caches.default(), Schedulers.boundedElastic(), tracerMock()).tap {
+        return new EthereumPosMultiStream(Chain.ETHEREUM, [up], Caches.default(), Schedulers.parallel(), tracerMock()).tap {
             start()
         }
     }
@@ -109,11 +109,11 @@ class TestingCommons {
     }
 
     static Multistream multistreamWithoutUpstreams(Chain chain) {
-        return new EthereumPosMultiStream(chain, [], emptyCaches().getCaches(chain), Schedulers.boundedElastic(), tracerMock())
+        return new EthereumPosMultiStream(chain, [], emptyCaches().getCaches(chain), Schedulers.parallel(), tracerMock())
     }
 
     static Multistream multistreamClassicWithoutUpstreams(Chain chain) {
-        return new EthereumMultistream(chain, [], emptyCaches().getCaches(chain), Schedulers.boundedElastic(), tracerMock())
+        return new EthereumMultistream(chain, [], emptyCaches().getCaches(chain), Schedulers.parallel(), tracerMock())
     }
 
     static FileResolver fileResolver() {

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/AbstractHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/AbstractHeadSpec.groovy
@@ -138,7 +138,7 @@ class AbstractHeadSpec extends Specification {
                 BlockContainer getHead() {
                     return null
                 }
-            }, Schedulers.boundedElastic(),   new BlockValidator.AlwaysValid() , 100_000)
+            }, Schedulers.parallel(),   new BlockValidator.AlwaysValid() , 100_000)
         }
     }
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/FilteredApisSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/FilteredApisSpec.groovy
@@ -56,8 +56,8 @@ class FilteredApisSpec extends Specification {
                     httpFactory,
                     new MostWorkForkChoice(),
                     BlockValidator.ALWAYS_VALID,
-                    Schedulers.boundedElastic(),
-                    Schedulers.boundedElastic()
+                    Schedulers.parallel(),
+                    Schedulers.parallel()
             )
             new EthereumRpcUpstream(
                     "test",

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/HeadLagObserverSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/HeadLagObserverSpec.groovy
@@ -117,7 +117,7 @@ class HeadLagObserverSpec extends Specification {
 
         TestHeadLagObserver(@NotNull Head master, @NotNull Collection<? extends Upstream> followers) {
             super(master, followers, DistanceExtractor.@Companion::extractPowDistance,
-                    Schedulers.boundedElastic(), Duration.ofNanos(1))
+                    Schedulers.parallel(), Duration.ofNanos(1))
         }
 
         @Override

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/MergedHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/MergedHeadSpec.groovy
@@ -37,7 +37,7 @@ class MergedHeadSpec extends Specification {
         }
 
         when:
-        def merged = new MergedHead([head1, head2, head3], new MostWorkForkChoice(), Schedulers.boundedElastic())
+        def merged = new MergedHead([head1, head2, head3], new MostWorkForkChoice(), Schedulers.parallel())
         merged.start()
 
         then:
@@ -46,14 +46,14 @@ class MergedHeadSpec extends Specification {
 
     class TestHead1 extends AbstractHead {
         TestHead1() {
-            super(new MostWorkForkChoice(), Schedulers.boundedElastic(), new BlockValidator.AlwaysValid(), 100_000)
+            super(new MostWorkForkChoice(), Schedulers.parallel(), new BlockValidator.AlwaysValid(), 100_000)
         }
     }
 
     class TestHead2 extends AbstractHead implements Lifecycle {
 
         TestHead2() {
-            super(new MostWorkForkChoice(), Schedulers.boundedElastic(), new BlockValidator.AlwaysValid(), 100_000)
+            super(new MostWorkForkChoice(), Schedulers.parallel(), new BlockValidator.AlwaysValid(), 100_000)
         }
 
         @Override

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/MultistreamSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/MultistreamSpec.groovy
@@ -51,7 +51,7 @@ class MultistreamSpec extends Specification {
         setup:
         def up1 = new EthereumPosRpcUpstreamMock("test1", Chain.ETHEREUM, TestingCommons.api(), new DirectCallMethods(["eth_test1", "eth_test2"]))
         def up2 = new EthereumPosRpcUpstreamMock("test1", Chain.ETHEREUM, TestingCommons.api(), new DirectCallMethods(["eth_test2", "eth_test3"]))
-        def aggr = new EthereumPosMultiStream(Chain.ETHEREUM, [up1, up2], Caches.default(), Schedulers.boundedElastic(), TestingCommons.tracerMock())
+        def aggr = new EthereumPosMultiStream(Chain.ETHEREUM, [up1, up2], Caches.default(), Schedulers.parallel(), TestingCommons.tracerMock())
         when:
         aggr.onUpstreamsUpdated()
         def act = aggr.getMethods()
@@ -187,7 +187,7 @@ class MultistreamSpec extends Specification {
         def up1 = TestingCommons.upstream("test-1", "internal")
         def up2 = TestingCommons.upstream("test-2", "external")
         def up3 = TestingCommons.upstream("test-3", "external")
-        def multistream = new EthereumPosMultiStream(Chain.ETHEREUM, [up1, up2, up3], Caches.default(), Schedulers.boundedElastic(), TestingCommons.tracerMock())
+        def multistream = new EthereumPosMultiStream(Chain.ETHEREUM, [up1, up2, up3], Caches.default(), Schedulers.parallel(), TestingCommons.tracerMock())
 
         expect:
         multistream.getHead(new Selector.LabelMatcher("provider", ["internal"])).is(up1.ethereumHeadMock)
@@ -255,7 +255,7 @@ class MultistreamSpec extends Specification {
     class TestEthereumPosMultistream extends EthereumPosMultiStream {
 
         TestEthereumPosMultistream(@NotNull Chain chain, @NotNull List<EthereumPosUpstream> upstreams, @NotNull Caches caches) {
-            super(chain, upstreams, caches, Schedulers.boundedElastic(), TestingCommons.tracerMock())
+            super(chain, upstreams, caches, Schedulers.parallel(), TestingCommons.tracerMock())
         }
 
         @NotNull

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/bitcoin/BitcoinRpcHeadSpec.groovy
@@ -86,7 +86,7 @@ class BitcoinRpcHeadSpec extends Specification {
             _ * read(new JsonRpcRequest("getblock", [hash1])) >> Mono.just(new JsonRpcResponse(block1.bytes, null))
             _ * read(new JsonRpcRequest("getblock", [hash2])) >> Mono.just(new JsonRpcResponse(block2.bytes, null))
         }
-        BitcoinRpcHead head = new BitcoinRpcHead(api, new ExtractBlock(), Duration.ofMillis(200), Schedulers.boundedElastic())
+        BitcoinRpcHead head = new BitcoinRpcHead(api, new ExtractBlock(), Duration.ofMillis(200), Schedulers.parallel())
 
         when:
         def act = head.flux.take(2)

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/DefaultEthereumHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/DefaultEthereumHeadSpec.groovy
@@ -32,7 +32,7 @@ import java.time.Instant
 
 class DefaultEthereumHeadSpec extends Specification {
 
-    DefaultEthereumHead head = new DefaultEthereumHead("upstream", new MostWorkForkChoice(), BlockValidator.ALWAYS_VALID, Schedulers.boundedElastic())
+    DefaultEthereumHead head = new DefaultEthereumHead("upstream", new MostWorkForkChoice(), BlockValidator.ALWAYS_VALID, Schedulers.parallel())
     ObjectMapper objectMapper = Global.objectMapper
     BlockHash parent = BlockHash.from("0x3ec2ebf5d0ec474d0ac6bc50d2770d8409ad76e119968e7919f85d5ec8915210")
 

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscriptionSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscriptionSpec.groovy
@@ -26,7 +26,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read empty logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([:])
 
@@ -37,7 +37,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read single address logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "0x829bd824b016326a401d083b33d092293333a830"
@@ -62,7 +62,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "ignores invalid address for logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "829bd824b016326a401d083b33d092293333a830"
@@ -75,7 +75,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read multi address logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: ["0x829bd824b016326a401d083b33d092293333a830", "0x401d083b33d092293333a83829bd824b016326a0"]
@@ -91,7 +91,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read single topic logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
@@ -116,7 +116,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read invalid topic for request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: [
@@ -134,7 +134,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read multi topic logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: [
@@ -153,7 +153,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read full logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "0x298d492e8c1d909d3f63bc4a36c66c64acb3d695",

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscriptionSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumEgressSubscriptionSpec.groovy
@@ -19,13 +19,14 @@ import io.emeraldpay.dshackle.test.TestingCommons
 import io.emeraldpay.dshackle.upstream.ethereum.subscribe.PendingTxesSource
 import io.emeraldpay.etherjar.domain.Address
 import io.emeraldpay.etherjar.hex.Hex32
+import reactor.core.scheduler.Schedulers
 import spock.lang.Specification
 
 class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read empty logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([:])
 
@@ -36,7 +37,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read single address logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "0x829bd824b016326a401d083b33d092293333a830"
@@ -61,7 +62,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "ignores invalid address for logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "829bd824b016326a401d083b33d092293333a830"
@@ -74,7 +75,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read multi address logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: ["0x829bd824b016326a401d083b33d092293333a830", "0x401d083b33d092293333a83829bd824b016326a0"]
@@ -90,7 +91,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read single topic logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
@@ -115,7 +116,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read invalid topic for request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: [
@@ -133,7 +134,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read multi topic logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 topics: [
@@ -152,7 +153,7 @@ class EthereumEgressSubscriptionSpec extends Specification {
 
     def "read full logs request"() {
         setup:
-        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Stub(PendingTxesSource))
+        def ethereumSubscribe = new EthereumEgressSubscription(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic(), Stub(PendingTxesSource))
         when:
         def act = ethereumSubscribe.readLogsRequest([
                 address: "0x298d492e8c1d909d3f63bc4a36c66c64acb3d695",

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumWsHeadSpec.groovy
@@ -66,7 +66,7 @@ class EthereumWsHeadSpec extends Specification {
             1 * it.connectionInfoFlux() >> Flux.empty()
         }
 
-        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, false, Schedulers.boundedElastic(), Schedulers.boundedElastic())
+        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, false, Schedulers.parallel(), Schedulers.parallel())
 
         when:
         def act = head.listenNewHeads().blockFirst()
@@ -107,7 +107,7 @@ class EthereumWsHeadSpec extends Specification {
             ]
         }
 
-        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.boundedElastic(), Schedulers.boundedElastic())
+        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.parallel(), Schedulers.parallel())
 
         when:
         def act = head.getFlux()
@@ -161,7 +161,7 @@ class EthereumWsHeadSpec extends Specification {
             ]
         }
 
-        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.boundedElastic(), Schedulers.boundedElastic())
+        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.parallel(), Schedulers.parallel())
 
         when:
         def act = head.getFlux()
@@ -201,7 +201,7 @@ class EthereumWsHeadSpec extends Specification {
             ]
         }
 
-        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.boundedElastic(), Schedulers.boundedElastic())
+        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.parallel(), Schedulers.parallel())
 
         when:
         def act = head.getFlux()
@@ -240,7 +240,7 @@ class EthereumWsHeadSpec extends Specification {
             ]
         }
 
-        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.boundedElastic(), Schedulers.boundedElastic())
+        def head = new EthereumWsHead("fake", new AlwaysForkChoice(), BlockValidator.ALWAYS_VALID, apiMock, ws, true, Schedulers.parallel(), Schedulers.parallel())
 
         when:
         def act = head.getFlux()

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImplRealSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImplRealSpec.groovy
@@ -5,6 +5,7 @@ import io.emeraldpay.dshackle.test.MockWSServer
 import io.emeraldpay.dshackle.upstream.DefaultUpstream
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcRequest
+import reactor.core.scheduler.Schedulers
 import reactor.test.StepVerifier
 import spock.lang.Shared
 import spock.lang.Specification
@@ -38,7 +39,8 @@ class WsConnectionImplRealSpec extends Specification {
                         "test",
                         Chain.ETHEREUM,
                         "ws://localhost:${port}".toURI(),
-                        "http://localhost:${port}".toURI()
+                        "http://localhost:${port}".toURI(),
+                        Schedulers.parallel()
                 )
         ).create(null).getConnection()
     }
@@ -117,7 +119,8 @@ class WsConnectionImplRealSpec extends Specification {
                         "test",
                         Chain.ETHEREUM,
                         "ws://localhost:${port}".toURI(),
-                        "http://localhost:${port}".toURI()
+                        "http://localhost:${port}".toURI(),
+                        Schedulers.parallel()
                 )
         ).create(up).getConnection()
         when:

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImplSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImplSpec.groovy
@@ -23,6 +23,7 @@ import io.emeraldpay.etherjar.domain.TransactionId
 import io.emeraldpay.etherjar.rpc.RpcResponseError
 import io.emeraldpay.etherjar.rpc.json.TransactionJson
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
 import reactor.test.StepVerifier
 import spock.lang.Specification
 
@@ -39,7 +40,8 @@ class WsConnectionImplSpec extends Specification {
                         "test",
                         Chain.ETHEREUM,
                         new URI("http://localhost"),
-                        new URI("http://localhost")
+                        new URI("http://localhost"),
+                        Schedulers.parallel()
                 )
         )
         def apiMock = TestingCommons.api()
@@ -73,7 +75,8 @@ class WsConnectionImplSpec extends Specification {
                         "test",
                         Chain.ETHEREUM,
                         new URI("http://localhost"),
-                        new URI("http://localhost")
+                        new URI("http://localhost"),
+                        Schedulers.parallel()
                 )
         )
         def apiMock = TestingCommons.api()
@@ -105,7 +108,8 @@ class WsConnectionImplSpec extends Specification {
                         "test",
                         Chain.ETHEREUM,
                         new URI("http://localhost"),
-                        new URI("http://localhost")
+                        new URI("http://localhost"),
+                        Schedulers.parallel()
                 )
         )
         def apiMock = TestingCommons.api()

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectBlockUpdatesSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectBlockUpdatesSpec.groovy
@@ -26,6 +26,7 @@ import io.emeraldpay.etherjar.domain.TransactionId
 import io.emeraldpay.etherjar.rpc.json.BlockJson
 import io.emeraldpay.etherjar.rpc.json.TransactionRefJson
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
 import spock.lang.Specification
 
 import java.time.Duration
@@ -37,7 +38,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Extracts updates"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream))
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
         def block = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -71,7 +72,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Produce DROP updates for replaced block"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream))
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
         def block = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -105,7 +106,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Gets prev version if available"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream))
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
         def block1 = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -169,7 +170,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Marks old txes as dropped before producing a new version of same block"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream))
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
         def block1 = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -234,7 +235,7 @@ class ConnectBlockUpdatesSpec extends Specification {
         def up = Mock(EthereumMultistream) {
             1 * getHead(Selector.empty) >> head
         }
-        def connectBlockUpdates = new ConnectBlockUpdates(up)
+        def connectBlockUpdates = new ConnectBlockUpdates(up, Schedulers.boundedElastic())
 
         when:
         def a1 = connectBlockUpdates.connect()

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectBlockUpdatesSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectBlockUpdatesSpec.groovy
@@ -38,7 +38,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Extracts updates"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.parallel())
         def block = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -72,7 +72,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Produce DROP updates for replaced block"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.parallel())
         def block = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -106,7 +106,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Gets prev version if available"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.parallel())
         def block1 = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -170,7 +170,7 @@ class ConnectBlockUpdatesSpec extends Specification {
 
     def "Marks old txes as dropped before producing a new version of same block"() {
         setup:
-        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.boundedElastic())
+        def connectBlockUpdates = new ConnectBlockUpdates(Stub(EthereumMultistream), Schedulers.parallel())
         def block1 = BlockContainer.from(new BlockJson<TransactionRefJson>().tap {
             hash = BlockHash.from("0xe5be2159b2b7daf6b126babdcbaa349da668b92d6b8c7db1350fd527fec4885c")
             number = 13412871
@@ -235,7 +235,7 @@ class ConnectBlockUpdatesSpec extends Specification {
         def up = Mock(EthereumMultistream) {
             1 * getHead(Selector.empty) >> head
         }
-        def connectBlockUpdates = new ConnectBlockUpdates(up, Schedulers.boundedElastic())
+        def connectBlockUpdates = new ConnectBlockUpdates(up, Schedulers.parallel())
 
         when:
         def a1 = connectBlockUpdates.connect()

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogsSpec.groovy
@@ -24,6 +24,7 @@ import io.emeraldpay.etherjar.domain.TransactionId
 import io.emeraldpay.etherjar.hex.Hex32
 import io.emeraldpay.etherjar.hex.HexData
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
 import spock.lang.Specification
 
 class ConnectLogsSpec extends Specification {
@@ -90,7 +91,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter is empty"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream)
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4
@@ -108,7 +109,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by address"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream)
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
         when:
         def input = Flux.fromIterable([
                 log1, log2
@@ -123,7 +124,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by topic"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream)
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4
@@ -140,7 +141,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by address and topic"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream)
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectLogsSpec.groovy
@@ -91,7 +91,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter is empty"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4
@@ -109,7 +109,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by address"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel())
         when:
         def input = Flux.fromIterable([
                 log1, log2
@@ -124,7 +124,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by topic"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4
@@ -141,7 +141,7 @@ class ConnectLogsSpec extends Specification {
 
     def "Filter by address and topic"() {
         setup:
-        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.boundedElastic())
+        def connectLogs = new ConnectLogs(TestingCommons.emptyMultistream() as EthereumPosMultiStream, Schedulers.parallel())
         when:
         def input = Flux.fromIterable([
                 log1, log2, log3, log4

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectNewHeadsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectNewHeadsSpec.groovy
@@ -21,7 +21,7 @@ class ConnectNewHeadsSpec extends Specification {
         def up = Mock(EthereumMultistream) {
             1 * getHead(Selector.empty) >> head
         }
-        ConnectNewHeads connectNewHeads = new ConnectNewHeads(up, Schedulers.boundedElastic())
+        ConnectNewHeads connectNewHeads = new ConnectNewHeads(up, Schedulers.parallel())
         when:
         def act1 = connectNewHeads.connect(Selector.empty)
         def act2 = connectNewHeads.connect(Selector.empty)

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectNewHeadsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ConnectNewHeadsSpec.groovy
@@ -5,6 +5,7 @@ import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Selector
 import io.emeraldpay.dshackle.upstream.ethereum.EthereumMultistream
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
 import reactor.test.StepVerifier
 import spock.lang.Specification
 
@@ -20,7 +21,7 @@ class ConnectNewHeadsSpec extends Specification {
         def up = Mock(EthereumMultistream) {
             1 * getHead(Selector.empty) >> head
         }
-        ConnectNewHeads connectNewHeads = new ConnectNewHeads(up)
+        ConnectNewHeads connectNewHeads = new ConnectNewHeads(up, Schedulers.boundedElastic())
         when:
         def act1 = connectNewHeads.connect(Selector.empty)
         def act2 = connectNewHeads.connect(Selector.empty)

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/EthereumGrpcUpstreamSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/EthereumGrpcUpstreamSpec.groovy
@@ -90,7 +90,7 @@ class EthereumGrpcUpstreamSpec extends Specification {
                 )
             }
         })
-        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, chain, client, new JsonRpcGrpcClient(client, chain, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.boundedElastic())
+        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, chain, client, new JsonRpcGrpcClient(client, chain, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.parallel())
         upstream.setLag(0)
         upstream.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()
@@ -161,7 +161,7 @@ class EthereumGrpcUpstreamSpec extends Specification {
                 }).start()
             }
         })
-        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, Chain.ETHEREUM, client, new JsonRpcGrpcClient(client, Chain.ETHEREUM, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.boundedElastic())
+        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, Chain.ETHEREUM, client, new JsonRpcGrpcClient(client, Chain.ETHEREUM, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.parallel())
         upstream.setLag(0)
         upstream.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()
@@ -233,7 +233,7 @@ class EthereumGrpcUpstreamSpec extends Specification {
                 finished.complete(true)
             }
         })
-        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, chain, client, new JsonRpcGrpcClient(client, chain, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.boundedElastic())
+        def upstream = new EthereumGrpcUpstream("test", hash, UpstreamsConfig.UpstreamRole.PRIMARY, chain, client, new JsonRpcGrpcClient(client, chain, metrics), null, ChainsConfig.ChainConfig.default(), Schedulers.parallel())
         upstream.setLag(0)
         upstream.update(
                 BlockchainOuterClass.DescribeChain.newBuilder()

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcHeadSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/grpc/GrpcHeadSpec.groovy
@@ -70,7 +70,7 @@ class GrpcHeadSpec extends Specification {
                 convert,
                 null,
                 new MostWorkForkChoice(),
-                Schedulers.boundedElastic()
+                Schedulers.parallel()
         )
         when:
         def act = head.getFlux()
@@ -137,7 +137,7 @@ class GrpcHeadSpec extends Specification {
                 convert,
                 null,
                 new MostWorkForkChoice(),
-                Schedulers.boundedElastic()
+                Schedulers.parallel()
         )
         when:
         def act = head.getFlux()


### PR DESCRIPTION
- use head scheduler instead of stock schedulers in other parts of system
- use parallel scheduler in tests for validate blocking operations