### PR TITLE
Checking eth_call return limit during node validation, currently 200k

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ChainsConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ChainsConfig.kt
@@ -11,6 +11,7 @@ data class ChainsConfig(private val chains: Map<Chain, RawChainConfig>, val curr
     data class RawChainConfig(
         var syncingLagSize: Int? = null,
         var laggingLagSize: Int? = null,
+        var callLimitContract: String? = null,
         var options: UpstreamsConfig.PartialOptions? = null
     ) {
 
@@ -26,11 +27,12 @@ data class ChainsConfig(private val chains: Map<Chain, RawChainConfig>, val curr
     data class ChainConfig(
         val syncingLagSize: Int,
         val laggingLagSize: Int,
-        val options: UpstreamsConfig.PartialOptions
+        val options: UpstreamsConfig.PartialOptions,
+        val callLimitContract: String?
     ) {
         companion object {
             @JvmStatic
-            fun default() = ChainConfig(6, 1, UpstreamsConfig.PartialOptions())
+            fun default() = ChainConfig(6, 1, UpstreamsConfig.PartialOptions(), null)
         }
     }
 
@@ -42,7 +44,8 @@ data class ChainsConfig(private val chains: Map<Chain, RawChainConfig>, val curr
         return ChainConfig(
             laggingLagSize = raw.laggingLagSize ?: default.laggingLagSize ?: panic(),
             syncingLagSize = raw.syncingLagSize ?: default.syncingLagSize ?: panic(),
-            options = options
+            options = options,
+            callLimitContract = raw.callLimitContract
         )
     }
 
@@ -57,7 +60,8 @@ data class ChainsConfig(private val chains: Map<Chain, RawChainConfig>, val curr
     ) = RawChainConfig(
         syncingLagSize = patch?.syncingLagSize ?: current.syncingLagSize,
         laggingLagSize = patch?.laggingLagSize ?: current.laggingLagSize,
-        options = patch?.options ?: current.options
+        options = patch?.options ?: current.options,
+        callLimitContract = patch?.callLimitContract ?: current.callLimitContract
     )
 
     private fun merge(

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ChainsConfigReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ChainsConfigReader.kt
@@ -53,6 +53,9 @@ class ChainsConfigReader(
                 rawConfig.laggingLagSize = it
             }
         }
+        getValueAsString(node, "call-validate-contract")?.let {
+            rawConfig.callLimitContract = it
+        }
         upstreamsConfigReader.tryReadOptions(node)?.let {
             rawConfig.options = it
         }

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfig.kt
@@ -36,7 +36,8 @@ open class UpstreamsConfig {
         val providesBalance: Boolean?,
         val validatePeers: Boolean,
         val minPeers: Int,
-        val validateSyncing: Boolean
+        val validateSyncing: Boolean,
+        val validateCallLimit: Boolean
     )
 
     open class PartialOptions {
@@ -51,6 +52,7 @@ open class UpstreamsConfig {
         var timeout: Duration? = null
         var providesBalance: Boolean? = null
         var validatePeers: Boolean? = null
+        var validateCalllimit: Boolean? = null
         var minPeers: Int? = null
             set(value) {
                 require(value == null || value >= 0) {
@@ -71,6 +73,7 @@ open class UpstreamsConfig {
             copy.validationInterval = firstNonNull(overwrites.validationInterval, this.validationInterval)
             copy.providesBalance = firstNonNull(overwrites.providesBalance, this.providesBalance)
             copy.validateSyncing = firstNonNull(overwrites.validateSyncing, this.validateSyncing)
+            copy.validateCalllimit = firstNonNull(overwrites.validateCalllimit, this.validateCalllimit)
             copy.timeout = firstNonNull(overwrites.timeout, this.timeout)
             return copy
         }
@@ -83,7 +86,8 @@ open class UpstreamsConfig {
                 this.providesBalance,
                 firstNonNull(this.validatePeers, true)!!,
                 firstNonNull(this.minPeers, 1)!!,
-                firstNonNull(this.validateSyncing, true)!!
+                firstNonNull(this.validateSyncing, true)!!,
+                firstNonNull(this.validateCalllimit, true)!!
             )
 
         companion object {

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfigReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfigReader.kt
@@ -353,6 +353,9 @@ class UpstreamsConfigReader(
         getValueAsBool(values, "validate-syncing")?.let {
             options.validateSyncing = it
         }
+        getValueAsBool(values, "validate-call-limit")?.let {
+            options.validateCalllimit = it
+        }
         getValueAsInt(values, "min-peers")?.let {
             options.minPeers = it
         }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeRpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeRpcUpstream.kt
@@ -45,7 +45,7 @@ open class EthereumLikeRpcUpstream(
     chainConfig: ChainsConfig.ChainConfig,
     skipEnhance: Boolean
 ) : EthereumLikeUpstream(id, hash, options, role, targets, node, chainConfig), Lifecycle, Upstream, CachesEnabled {
-    private val validator: EthereumUpstreamValidator = EthereumUpstreamValidator(this, getOptions())
+    private val validator: EthereumUpstreamValidator = EthereumUpstreamValidator(this, getOptions(), chainConfig.callLimitContract)
     private val connector: EthereumConnector = connectorFactory.create(this, validator, chain, skipEnhance)
     private val labelsDetector = EthereumLabelsDetector(this.getIngressReader())
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeUpstream.kt
@@ -30,7 +30,7 @@ abstract class EthereumLikeUpstream(
     role: UpstreamsConfig.UpstreamRole,
     targets: CallMethods?,
     private val node: QuorumForLabels.QuorumItem?,
-    chainConfig: ChainsConfig.ChainConfig
+    val chainConfig: ChainsConfig.ChainConfig
 ) : DefaultUpstream(id, hash, options, role, targets, node, chainConfig) {
 
     private val capabilities = if (options.providesBalance != false) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumUpstreamValidator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumUpstreamValidator.kt
@@ -24,21 +24,26 @@ import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.UpstreamAvailability
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcRequest
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcResponse
+import io.emeraldpay.etherjar.domain.Address
+import io.emeraldpay.etherjar.hex.HexData
 import io.emeraldpay.etherjar.rpc.json.SyncingJson
+import io.emeraldpay.etherjar.rpc.json.TransactionCallJson
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
-import reactor.util.function.Tuple2
+import reactor.util.function.Tuple3
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeoutException
 
-open class EthereumUpstreamValidator(
+open class EthereumUpstreamValidator @JvmOverloads constructor(
     private val upstream: Upstream,
-    private val options: UpstreamsConfig.Options
+    private val options: UpstreamsConfig.Options,
+    private val callLimitContract: String? = null
 ) {
+    private var callLimitSucceed: Boolean = false
     companion object {
         private val log = LoggerFactory.getLogger(EthereumUpstreamValidator::class.java)
         val scheduler =
@@ -50,15 +55,47 @@ open class EthereumUpstreamValidator(
     open fun validate(): Mono<UpstreamAvailability> {
         return Mono.zip(
             validateSyncing(),
-            validatePeers()
+            validatePeers(),
+            validateCallLimit()
         )
             .map(::resolve)
             .defaultIfEmpty(UpstreamAvailability.UNAVAILABLE)
             .onErrorReturn(UpstreamAvailability.UNAVAILABLE)
     }
 
-    fun resolve(results: Tuple2<UpstreamAvailability, UpstreamAvailability>): UpstreamAvailability {
-        return if (results.t1.isBetterTo(results.t2)) results.t2 else results.t1
+    fun resolve(results: Tuple3<UpstreamAvailability, UpstreamAvailability, UpstreamAvailability>): UpstreamAvailability {
+        val cp = Comparator { avail1: UpstreamAvailability, avail2: UpstreamAvailability -> if (avail1.isBetterTo(avail2)) -1 else 1 }
+        return listOf(results.t1, results.t2, results.t3).sortedWith(cp).last()
+    }
+
+    fun validateCallLimit(): Mono<UpstreamAvailability> {
+        // do not rerun this check after first success because it's more expensive than others
+        if (!options.validateCallLimit || callLimitContract == null || callLimitSucceed) {
+            return Mono.just(UpstreamAvailability.OK)
+        }
+        return upstream.getIngressReader()
+            .read(
+                JsonRpcRequest(
+                    "eth_call",
+                    listOf(
+                        TransactionCallJson(
+                            Address.from(callLimitContract),
+                            // calling contract with param 200_000, meaning it will generate 200k symbols or response
+                            // 30d40 — 200_000
+                            HexData.from("0xd8a26e3a0000000000000000000000000000000000000000000000000000000000030d40")
+                        )
+                    )
+                )
+            )
+            .flatMap(JsonRpcResponse::requireResult)
+            .map { UpstreamAvailability.OK }
+            .timeout(
+                Defaults.timeoutInternal,
+                Mono.fromCallable { log.warn("No response for eth_call limit check from ${upstream.getId()}") }
+                    .then(Mono.error(TimeoutException("Validation timeout for Syncing")))
+            )
+            .doOnSuccess { callLimitSucceed = true }
+            .onErrorReturn(UpstreamAvailability.UNAVAILABLE)
     }
 
     fun validateSyncing(): Mono<UpstreamAvailability> {

--- a/src/main/resources/chains.yaml
+++ b/src/main/resources/chains.yaml
@@ -7,6 +7,12 @@ chain-settings:
       lagging: 1
   chains:
     - id: eth
+      call-validate-contract: 0x32268860cAAc2948Ab5DdC7b20db5a420467Cf96
+      lags:
+        syncing: 6
+        lagging: 1
+    - id: goerli
+      call-validate-contract: 0xCD9303A1F6da2a68f465A579a24cc2Ee5AE2192f
       lags:
         syncing: 6
         lagging: 1

--- a/src/test/groovy/io/emeraldpay/dshackle/config/ChainsConfigReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/config/ChainsConfigReaderSpec.groovy
@@ -38,6 +38,7 @@ class ChainsConfigReaderSpec extends Specification {
         then:
         eth.laggingLagSize == 1
         eth.syncingLagSize == 6
+        eth.callLimitContract == "0x32268860cAAc2948Ab5DdC7b20db5a420467Cf96"
 
         pol.laggingLagSize == 10
         pol.syncingLagSize == 20
@@ -48,8 +49,5 @@ class ChainsConfigReaderSpec extends Specification {
 
         sep.laggingLagSize == 1
         sep.syncingLagSize == 10
-
-        eth.laggingLagSize == 1
-        eth.syncingLagSize == 6
     }
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/config/UpstreamsConfigReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/config/UpstreamsConfigReaderSpec.groovy
@@ -450,11 +450,13 @@ class UpstreamsConfigReaderSpec extends Specification {
             disableValidation == false
             validateSyncing == true
             validatePeers == false
+            validateCalllimit == true
         }
         with(act.upstreams.get(1).options) {
             disableValidation == false
             validateSyncing == false
             validatePeers == false
+            validateCalllimit == false
         }
         with(act.upstreams.get(2).options) {
             disableValidation == true
@@ -633,7 +635,7 @@ class UpstreamsConfigReaderSpec extends Specification {
         def options = partialOptions.buildOptions()
         then:
         options == new UpstreamsConfig.Options(
-                false, 30, Duration.ofSeconds(60), null, true, 1, true
+                false, 30, Duration.ofSeconds(60), null, true, 1, true, true
         )
     }
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/test/EthereumPosRpcUpstreamMock.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/EthereumPosRpcUpstreamMock.groovy
@@ -18,6 +18,7 @@ package io.emeraldpay.dshackle.test
 
 import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.config.ChainsConfig
+import io.emeraldpay.dshackle.config.ChainsConfig.ChainConfig
 import io.emeraldpay.dshackle.config.UpstreamsConfig
 import io.emeraldpay.dshackle.config.UpstreamsConfig.Options
 import io.emeraldpay.dshackle.data.BlockContainer
@@ -70,7 +71,7 @@ class EthereumPosRpcUpstreamMock extends EthereumLikeRpcUpstream {
                 methods,
                 new QuorumForLabels.QuorumItem(1, UpstreamsConfig.Labels.fromMap(labels)),
                 new ConnectorFactoryMock(api, new EthereumHeadMock()),
-                ChainsConfig.ChainConfig.default(),
+                ChainConfig.default(),
                 true
         )
         this.ethereumHeadMock = this.getHead() as EthereumHeadMock

--- a/src/test/groovy/io/emeraldpay/dshackle/test/TestingCommons.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/test/TestingCommons.groovy
@@ -21,6 +21,7 @@ import io.emeraldpay.dshackle.FileResolver
 import io.emeraldpay.dshackle.cache.Caches
 import io.emeraldpay.dshackle.cache.CachesFactory
 import io.emeraldpay.dshackle.config.CacheConfig
+import io.emeraldpay.dshackle.config.ChainsConfig.ChainConfig
 import io.emeraldpay.dshackle.data.BlockContainer
 import io.emeraldpay.dshackle.data.BlockId
 import io.emeraldpay.dshackle.reader.EmptyReader

--- a/src/test/resources/configs/chains-basic.yaml
+++ b/src/test/resources/configs/chains-basic.yaml
@@ -7,6 +7,7 @@ chain-settings:
       lagging: 1
   chains:
     - id: eth
+      call-validate-contract: 0x32268860cAAc2948Ab5DdC7b20db5a420467Cf96
       lags:
         syncing: 6
         lagging: 1

--- a/src/test/resources/configs/upstreams-validation.yaml
+++ b/src/test/resources/configs/upstreams-validation.yaml
@@ -8,6 +8,7 @@ upstreams:
       disable-validation: false
       validate-syncing: true
       validate-peers: false
+      validate-call-limit: true
     connection:
       ethereum:
         rpc:
@@ -19,6 +20,7 @@ upstreams:
       disable-validation: false
       validate-syncing: false
       validate-peers: false
+      validate-call-limit: false
     connection:
       ethereum:
         rpc:


### PR DESCRIPTION
Added new kind of validation, that check return limit for a node. Default return limit is 100k, we need at least 200k.

Infura, Alchemy do not have limit, they just rely on gas limit to limit the return. So, we may increase this limit in future, however it opens potential exploits.

Now limit is tested for 2 networks: Goerli and Ethereum Mainnet, because we use custom smart contract to generate huge responses, contract code is: `
```solidity
pragma solidity ^0.8.12;

contract testContract {

    constructor () {
    }
    
    function get (uint32 size) view public returns(bytes32[] memory) {
        uint iter = size / 32 + 1;
        bytes32 pattern = blockhash(block.number - 1);
        bytes32[] memory accum = new bytes32[](iter);
        for (uint32 i = 0; i < iter; i++) 
        {
            accum[i] = pattern;
        }
        return accum;
    }
}
```