### PR TITLE
Return upstreamId in response for errors too

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
@@ -28,7 +28,6 @@ open class BroadcastQuorum(
     private var txid: String? = null
     private var calls = 0
     private var sig: ResponseSigner.Signature? = null
-    private var providedUpstreamId: String? = null
 
     override fun init(head: Head) {
     }
@@ -49,23 +48,17 @@ open class BroadcastQuorum(
         return sig
     }
 
-    override fun getProvidedUpstreamId(): String? {
-        return providedUpstreamId
-    }
-
     override fun recordValue(
         response: ByteArray,
         responseValue: String?,
         signature: ResponseSigner.Signature?,
-        upstream: Upstream,
-        providedUpstreamId: String?
+        upstream: Upstream
     ) {
         calls++
         if (txid == null && responseValue != null) {
             txid = responseValue
             sig = signature
             result = response
-            this.providedUpstreamId = providedUpstreamId
         }
     }
 
@@ -73,16 +66,15 @@ open class BroadcastQuorum(
         response: ByteArray?,
         errorMessage: String?,
         signature: ResponseSigner.Signature?,
-        upstream: Upstream,
-        providedUpstreamId: String?
+        upstream: Upstream
     ) {
         // can be "message: known transaction: TXID", "Transaction with the same hash was already imported" or "message: Nonce too low"
         calls++
         if (result == null) {
             result = response
             sig = signature
-            this.providedUpstreamId = providedUpstreamId
         }
+        resolvers.add(upstream)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/CallQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/CallQuorum.kt
@@ -32,9 +32,9 @@ interface CallQuorum {
     fun record(
         response: ByteArray,
         signature: ResponseSigner.Signature?,
-        upstream: Upstream,
-        providedUpstreamId: String?
+        upstream: Upstream
     ): Boolean
+
     fun record(
         error: JsonRpcException,
         signature: ResponseSigner.Signature?,
@@ -42,7 +42,6 @@ interface CallQuorum {
     )
     fun getSignature(): ResponseSigner.Signature?
 
-    fun getProvidedUpstreamId(): String?
     fun getResult(): ByteArray?
     fun getError(): JsonRpcError?
     fun getResolvedBy(): Collection<Upstream>

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotNullQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotNullQuorum.kt
@@ -30,7 +30,6 @@ class NotNullQuorum : CallQuorum {
         allFailed = false
         val receivedNull = response.isEmpty() || Global.nullValue.contentEquals(response)
         val upId = upstream.getId()
-        if (upId == "infura2") return false
         if (seenUpstreams.contains(upId) || !receivedNull) {
             sig = signature
             result = response

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
@@ -377,6 +377,7 @@ open class WsConnectionImpl(
                 RpcResponseError.CODE_INTERNAL_ERROR,
                 "Response not received from WebSocket"
             ),
+            null,
             false
         )
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcError.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcError.kt
@@ -31,6 +31,10 @@ data class JsonRpcError(val code: Int, val message: String, val details: Any?) {
     }
 
     fun asException(id: JsonRpcResponse.Id?): JsonRpcException {
-        return JsonRpcException(id ?: JsonRpcResponse.NumberId(-1), this, false)
+        return JsonRpcException(id ?: JsonRpcResponse.NumberId(-1), this, null, false)
+    }
+
+    fun asException(id: JsonRpcResponse.Id?, upstreamId: String?): JsonRpcException {
+        return JsonRpcException(id ?: JsonRpcResponse.NumberId(-1), this, upstreamId, false)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcException.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcException.kt
@@ -20,6 +20,7 @@ import io.emeraldpay.etherjar.rpc.RpcException
 class JsonRpcException(
     val id: JsonRpcResponse.Id,
     val error: JsonRpcError,
+    val upstreamId: String? = null,
     writableStackTrace: Boolean = true
 ) : Exception(error.message, null, true, writableStackTrace) {
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcHttpClient.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcHttpClient.kt
@@ -131,7 +131,7 @@ class JsonRpcHttpClient(
         return Function { resp ->
             resp.flatMap {
                 if (it.hasError()) {
-                    Mono.error(JsonRpcException(it.id, it.error!!, false))
+                    Mono.error(JsonRpcException(it.id, it.error!!, null, false))
                 } else {
                     Mono.just(it)
                 }

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/WriteRpcJsonSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/WriteRpcJsonSpec.groovy
@@ -98,7 +98,7 @@ class WriteRpcJsonSpec extends Specification {
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)
         call.ids[1] = 1
         def data = [
-                new NativeCall.CallResult(1, null, null, new NativeCall.CallError(1, "Internal Error", null, null), null, null, null)
+                new NativeCall.CallResult(1, null, null, new NativeCall.CallError(1, "Internal Error", null, null, null), null, null, null)
         ]
         when:
         def act = writer.toJson(call, data[0])
@@ -127,7 +127,7 @@ class WriteRpcJsonSpec extends Specification {
         call.ids[3] = 15
         def data = [
                 new NativeCall.CallResult(1, null, '"0x98dbb1"'.bytes, null, null, null, null),
-                new NativeCall.CallResult(2, null, null, new NativeCall.CallError(2, "oops", null, null), null, null, null),
+                new NativeCall.CallResult(2, null, null, new NativeCall.CallError(2, "oops", null, null, null), null, null, null),
                 new NativeCall.CallResult(3, null, '{"hash": "0x2484f459dc"}'.bytes, null, null, null, null),
         ]
         when:

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/AlwaysQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/AlwaysQuorumSpec.groovy
@@ -42,7 +42,7 @@ class AlwaysQuorumSpec extends Specification {
         def quorum = new AlwaysQuorum()
         def up = Stub(Upstream)
         when:
-        quorum.record("123".bytes, new ResponseSigner.Signature("sig1".bytes, "test", 100), up, null)
+        quorum.record("123".bytes, new ResponseSigner.Signature("sig1".bytes, "test", 100), up)
         then:
         quorum.isResolved()
         quorum.getResult() == "123".bytes

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/BroadcastQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/BroadcastQuorumSpec.groovy
@@ -40,21 +40,21 @@ class BroadcastQuorumSpec extends Specification {
         !q.isResolved()
 
         when:
-        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream1, null)
+        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream1)
         then:
         !q.isResolved()
-        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _, _)
+        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _)
 
         when:
-        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream2, null)
+        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream2)
         then:
         !q.isResolved()
-        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _, _)
+        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _)
 
         when:
         q.record(new JsonRpcException(1, "Nonce too low"), null, upstream3)
         then:
-        1 * q.recordError(_, _, _, _, _)
+        1 * q.recordError(_, _, _, _)
         q.isResolved()
         objectMapper.readValue(q.result, Object) == "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"
     }
@@ -75,18 +75,18 @@ class BroadcastQuorumSpec extends Specification {
         q.record(new JsonRpcException(1, "Internal error"), null, upstream1)
         then:
         !q.isResolved()
-        1 * q.recordError(_, _, _, _, _)
+        1 * q.recordError(_, _, _, _)
 
         when:
-        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream2, null)
+        q.record('"0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"'.bytes, null, upstream2)
         then:
         !q.isResolved()
-        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _, _)
+        1 * q.recordValue(_, "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c", _, _)
 
         when:
         q.record(new JsonRpcException(1, "Nonce too low"), null, upstream3)
         then:
-        1 * q.recordError(_, _, _, _, _)
+        1 * q.recordError(_, _, _, _)
         q.isResolved()
         objectMapper.readValue(q.result, Object) == "0xeaa972c0d8d1ecd3e34fbbef6d34e06670e745c788bdba31c4234a1762f0378c"
     }

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/NotLaggingQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/NotLaggingQuorumSpec.groovy
@@ -30,7 +30,7 @@ class NotLaggingQuorumSpec extends Specification {
         def quorum = new NotLaggingQuorum(1)
 
         when:
-        quorum.record(value, null, up, null)
+        quorum.record(value, null, up)
         then:
         1 * up.getLag() >> 0
         quorum.isResolved()
@@ -45,14 +45,13 @@ class NotLaggingQuorumSpec extends Specification {
         def quorum = new NotLaggingQuorum(1)
 
         when:
-        quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up, "test")
+        quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up)
         then:
         1 * up.getLag() >> 0
         quorum.isResolved()
         !quorum.isFailed()
         quorum.result == value
         quorum.signature == new ResponseSigner.Signature("sig1".bytes, "test", 100)
-        quorum.providedUpstreamId == "test"
     }
 
     def "Resolves if ok lag"() {
@@ -62,7 +61,7 @@ class NotLaggingQuorumSpec extends Specification {
         def quorum = new NotLaggingQuorum(1)
 
         when:
-        quorum.record(value, null, up, null)
+        quorum.record(value, null, up)
         then:
         1 * up.getLag() >> 1
         quorum.isResolved()
@@ -77,7 +76,7 @@ class NotLaggingQuorumSpec extends Specification {
         def quorum = new NotLaggingQuorum(1)
 
         when:
-        quorum.record(value, null, up, null)
+        quorum.record(value, null, up)
         then:
         1 * up.getLag() >> 2
         !quorum.isResolved()

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/NotNullQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/NotNullQuorumSpec.groovy
@@ -22,10 +22,10 @@ class NotNullQuorumSpec extends Specification {
         def quorum = new NotNullQuorum()
 
         when:
-        def res = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up, "id")
-        def res1 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up1, "id1")
-        def res2 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up2, "id2")
-        def res3 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up, "id")
+        def res = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up)
+        def res1 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up1)
+        def res2 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up2)
+        def res3 = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up)
         then:
         !res
         !res1
@@ -35,7 +35,6 @@ class NotNullQuorumSpec extends Specification {
         !quorum.isFailed()
         quorum.isResolved()
         quorum.signature == new ResponseSigner.Signature("sig1".bytes, "test", 100)
-        quorum.providedUpstreamId == "id"
     }
 
     def "Failed if all upstreams respond with error"() {
@@ -78,7 +77,7 @@ class NotNullQuorumSpec extends Specification {
         def quorum = new NotNullQuorum()
 
         when:
-        def res = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up, "id")
+        def res = quorum.record(value, new ResponseSigner.Signature("sig1".bytes, "test", 100), up)
         quorum.record(new JsonRpcException(10, "error"), new ResponseSigner.Signature("sig1".bytes, "test", 100), up1)
         quorum.record(new JsonRpcException(10, "error"), new ResponseSigner.Signature("sig1".bytes, "test", 100), up2)
         quorum.record(new JsonRpcException(10, "error"), new ResponseSigner.Signature("sig1".bytes, "test", 100), up)

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/ValueAwareQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/ValueAwareQuorumSpec.groovy
@@ -66,14 +66,14 @@ class ValueAwareQuorumSpec extends Specification {
         }
 
         @Override
-        void recordValue(@NotNull byte[] response, @Nullable Object responseValue, @Nullable ResponseSigner.Signature signature, @NotNull Upstream upstream, @Nullable String providedUpstreamId) {
+        void recordValue(@NotNull byte[] response, @Nullable Object responseValue, @Nullable ResponseSigner.Signature signature, @NotNull Upstream upstream) {
 
         }
 
 
 
         @Override
-        void recordError(@Nullable byte[] response, @Nullable String errorMessage, @Nullable ResponseSigner.Signature signature, @NotNull Upstream upstream, @Nullable String providedUpstreamId) {
+        void recordError(@Nullable byte[] response, @Nullable String errorMessage, @Nullable ResponseSigner.Signature signature, @NotNull Upstream upstream) {
 
         }
 
@@ -100,11 +100,6 @@ class ValueAwareQuorumSpec extends Specification {
         @Override
         boolean isFailed() {
             return false
-        }
-
-        @Override
-        String getProvidedUpstreamId() {
-            return null
         }
     }
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/rpc/NativeCallSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/rpc/NativeCallSpec.groovy
@@ -134,7 +134,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall()
         nativeCall.quorumReaderFactory = Mock(QuorumReaderFactory) {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
-                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"foo\"".bytes, null, 1, Collections.singletonList(ups), null))
+                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"foo\"".bytes, null, 1, ups))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, TestingCommons.multistream(TestingCommons.api()), Selector.empty, quorum,
@@ -181,7 +181,7 @@ class NativeCallSpec extends Specification {
         nativeCall.quorumReaderFactory = Mock(QuorumReaderFactory) {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_test", [], 10)) >> Mono.error(
-                        new JsonRpcException(JsonRpcResponse.Id.from(12), new JsonRpcError(-32123, "Foo Bar", "Foo Bar Baz"), true)
+                        new JsonRpcException(JsonRpcResponse.Id.from(12), new JsonRpcError(-32123, "Foo Bar", "Foo Bar Baz"), null, true)
                 )
             }
         }
@@ -617,7 +617,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall(multistreamHolder)
         nativeCall.quorumReaderFactory = Mock(QuorumReaderFactory) {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
-                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"0xab\"".bytes, null, 1, Collections.singletonList(ups), null))
+                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"0xab\"".bytes, null, 1, ups))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, multistream, Selector.empty, quorum,
@@ -652,7 +652,7 @@ class NativeCallSpec extends Specification {
         def nativeCall = nativeCall(multistreamHolder)
         nativeCall.quorumReaderFactory = Mock(QuorumReaderFactory) {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
-                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"0xab\"".bytes, null, 1, Collections.singletonList(ups), null))
+                1 * read(_) >> Mono.just(new QuorumRpcReader.Result("\"0xab\"".bytes, null, 1, ups))
             }
         }
         def call = new NativeCall.ValidCallContext(1, 10, multistream, Selector.empty, quorum,

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
@@ -13,6 +13,7 @@ import io.emeraldpay.dshackle.upstream.ApiSource
 import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Multistream
 import io.emeraldpay.dshackle.upstream.Selector
+import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.calls.DefaultEthereumMethods
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcRequest
 import io.emeraldpay.etherjar.domain.Address
@@ -34,7 +35,7 @@ class EthereumDirectReaderSpec extends Specification {
 
     String hash1 = "0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5"
     String address1 = "0xe0aadb0a012dbcdc529c4c743d3e0385a0b54d3d"
-    List<Byte> resolvers = Collections.singletonList((byte)1)
+    Upstream resolver = TestingCommons.upstream()
 
     def "Reads block by hash"() {
         setup:
@@ -59,7 +60,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _,) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getBlockByHash", [hash1, false])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolvers, null)
+                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolver)
                 )
             }
         }
@@ -89,7 +90,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getBlockByHash", [hash1, false])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(null), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes(null), null, 1, resolver
                         )
                 )
             }
@@ -127,7 +128,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getBlockByNumber", ["0x64", false])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolver
                         )
                 )
             }
@@ -163,7 +164,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getTransactionByHash", [hash1])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolver
                         )
                 )
             }
@@ -199,7 +200,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getTransactionReceipt", [hash1])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(json), null, 1, new ArrayList<Byte>(), null
+                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolver
                         )
                 )
             }
@@ -236,7 +237,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getTransactionReceipt", [hash1])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(json), null, 1, new ArrayList<Byte>(), null
+                                Global.objectMapper.writeValueAsBytes(json), null, 1, resolver
                         )
                 )
             }
@@ -264,7 +265,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getTransactionByHash", [hash1])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes(null), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes(null), null, 1, resolver
                         )
                 )
             }
@@ -295,7 +296,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getBalance", [address1, "latest"])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes("0x100"), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes("0x100"), null, 1, resolver
                         )
                 )
             }
@@ -327,7 +328,7 @@ class EthereumDirectReaderSpec extends Specification {
             1 * create(_, _, _, _) >> Mock(QuorumReader) {
                 1 * read(new JsonRpcRequest("eth_getBalance", [address1, "0xa8c9bb"])) >> Mono.just(
                         new QuorumRpcReader.Result(
-                                Global.objectMapper.writeValueAsBytes("0x100"), null, 1, resolvers, null
+                                Global.objectMapper.writeValueAsBytes("0x100"), null, 1, resolver
                         )
                 )
             }
@@ -359,7 +360,7 @@ class EthereumDirectReaderSpec extends Specification {
         }
         def result = Mono.just(
                 new QuorumRpcReader.Result(
-                        Global.objectMapper.writeValueAsBytes(json), null, 1, resolvers, null)
+                        Global.objectMapper.writeValueAsBytes(json), null, 1, resolver)
         )
         EthereumDirectReader ethereumDirectReader = new EthereumDirectReader(
                 up, Caches.default(), new CurrentBlockCache(), calls, TestingCommons.tracerMock()
@@ -402,7 +403,7 @@ class EthereumDirectReaderSpec extends Specification {
         }
         def result = Mono.just(
                 new QuorumRpcReader.Result(
-                        Global.objectMapper.writeValueAsBytes(json), null, 1, resolvers, null)
+                        Global.objectMapper.writeValueAsBytes(json), null, 1, resolver)
         )
         EthereumDirectReader ethereumDirectReader = new EthereumDirectReader(
                 up, Caches.default(), new CurrentBlockCache(), calls, TestingCommons.tracerMock()


### PR DESCRIPTION
- return `upstreamId` in native call response for errors not only for positive cases
- remove response upstreamId from span in dshackle, it should be moved to dproxy side
- refactoring of `CallQuorum` classes, there were an overhead using upstreams and `providedUpstreamId`