### PR TITLE
Return upstreamId from direct reader

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/TrackEthereumAddress.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/TrackEthereumAddress.kt
@@ -121,6 +121,7 @@ class TrackEthereumAddress(
             .balance()
             .read(addr.address)
             .timeout(Defaults.timeout)
+            .map { it.data }
     }
 
     private fun buildResponse(address: TrackedAddress): BlockchainOuterClass.AddressBalance {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumDirectReader.kt
@@ -53,74 +53,79 @@ class EthereumDirectReader(
     private val objectMapper: ObjectMapper = Global.objectMapper
     var quorumReaderFactory: QuorumReaderFactory = QuorumReaderFactory.default()
 
-    val blockReader: Reader<BlockHash, BlockContainer>
-    val blockByHeightReader: Reader<Long, BlockContainer>
-    val txReader: Reader<TransactionId, TxContainer>
-    val balanceReader: Reader<Address, Wei>
-    val receiptReader: Reader<TransactionId, ByteArray>
+    val blockReader: Reader<BlockHash, Result<BlockContainer>>
+    val blockByHeightReader: Reader<Long, Result<BlockContainer>>
+    val txReader: Reader<TransactionId, Result<TxContainer>>
+    val balanceReader: Reader<Address, Result<Wei>>
+    val receiptReader: Reader<TransactionId, Result<ByteArray>>
 
     init {
-        blockReader = object : Reader<BlockHash, BlockContainer> {
-            override fun read(key: BlockHash): Mono<BlockContainer> {
+        blockReader = object : Reader<BlockHash, Result<BlockContainer>> {
+            override fun read(key: BlockHash): Mono<Result<BlockContainer>> {
                 val request = JsonRpcRequest("eth_getBlockByHash", listOf(key.toHex(), false))
                 return readBlock(request, key.toHex())
             }
         }
-        blockByHeightReader = object : Reader<Long, BlockContainer> {
-            override fun read(key: Long): Mono<BlockContainer> {
+        blockByHeightReader = object : Reader<Long, Result<BlockContainer>> {
+            override fun read(key: Long): Mono<Result<BlockContainer>> {
                 val heightMatcher = Selector.HeightMatcher(key)
                 val request = JsonRpcRequest("eth_getBlockByNumber", listOf(HexQuantity.from(key).toHex(), false))
                 return readBlock(request, key.toString(), heightMatcher)
             }
         }
-        txReader = object : Reader<TransactionId, TxContainer> {
-            override fun read(key: TransactionId): Mono<TxContainer> {
+        txReader = object : Reader<TransactionId, Result<TxContainer>> {
+            override fun read(key: TransactionId): Mono<Result<TxContainer>> {
                 val request = JsonRpcRequest("eth_getTransactionByHash", listOf(key.toHex()))
                 return readWithQuorum(request) // retries were removed because we use NotNullQuorum which handle errors too
                     .timeout(Defaults.timeoutInternal, Mono.error(TimeoutException("Tx not read $key")))
-                    .flatMap { txbytes ->
-                        val tx = objectMapper.readValue(txbytes, TransactionJsonSnapshot::class.java)
+                    .flatMap { result ->
+                        val tx = objectMapper.readValue(result.data, TransactionJsonSnapshot::class.java)
                         if (tx == null) {
                             Mono.empty()
                         } else {
-                            Mono.just(TxContainer.from(tx, txbytes))
+                            Mono.just(
+                                Result(TxContainer.from(tx, result.data), result.upstreamId)
+                            )
                         }
                     }
                     .doOnNext { tx ->
-                        if (tx.blockId != null) {
-                            caches.cache(Caches.Tag.REQUESTED, tx)
+                        if (tx.data.blockId != null) {
+                            caches.cache(Caches.Tag.REQUESTED, tx.data)
                         }
                     }
             }
         }
-        balanceReader = object : Reader<Address, Wei> {
-            override fun read(key: Address): Mono<Wei> {
+        balanceReader = object : Reader<Address, Result<Wei>> {
+            override fun read(key: Address): Mono<Result<Wei>> {
                 val height = up.getHead().getCurrentHeight()?.let { HexQuantity.from(it).toHex() } ?: "latest"
                 val request = JsonRpcRequest("eth_getBalance", listOf(key.toHex(), height))
                 return readWithQuorum(request)
                     .timeout(Defaults.timeoutInternal, Mono.error(TimeoutException("Balance not read $key")))
                     .map {
-                        val str = String(it)
+                        val str = String(it.data)
                         // it's a json string, i.e. wrapped with quotes, ex. _"0x1234"_
                         if (str.startsWith("\"") && str.endsWith("\"")) {
-                            Wei.from(str.substring(1, str.length - 1))
+                            Result(
+                                Wei.from(str.substring(1, str.length - 1)),
+                                it.upstreamId
+                            )
                         } else {
                             throw RpcException(RpcResponseError.CODE_UPSTREAM_INVALID_RESPONSE, "Not Wei value")
                         }
                     }
                     .retryWhen(Retry.fixedDelay(3, Duration.ofMillis(200)))
                     .doOnNext { value ->
-                        balanceCache.put(key, value)
+                        balanceCache.put(key, value.data)
                     }
             }
         }
-        receiptReader = object : Reader<TransactionId, ByteArray> {
-            override fun read(key: TransactionId): Mono<ByteArray> {
+        receiptReader = object : Reader<TransactionId, Result<ByteArray>> {
+            override fun read(key: TransactionId): Mono<Result<ByteArray>> {
                 val request = JsonRpcRequest("eth_getTransactionReceipt", listOf(key.toHex()))
                 return readWithQuorum(request)
                     .timeout(Defaults.timeoutInternal, Mono.error(TimeoutException("Receipt not read $key")))
-                    .flatMap { json ->
-                        val receipt = objectMapper.readValue(json, TransactionReceiptJson::class.java)
+                    .flatMap { result ->
+                        val receipt = objectMapper.readValue(result.data, TransactionReceiptJson::class.java)
                         if (receipt == null) {
                             log.debug("Empty receipt for txId $key")
                             Mono.empty()
@@ -131,11 +136,13 @@ class EthereumDirectReader(
                                     txId = TxId.from(key),
                                     blockId = BlockId.from(receipt.blockHash),
                                     height = receipt.blockNumber,
-                                    json = json,
+                                    json = result.data,
                                     parsed = receipt
                                 )
                             )
-                            Mono.just(json)
+                            Mono.just(
+                                result
+                            )
                         }
                     }
             }
@@ -147,27 +154,35 @@ class EthereumDirectReader(
         request: JsonRpcRequest,
         id: String,
         matcher: Selector.Matcher = Selector.empty
-    ): Mono<BlockContainer> {
+    ): Mono<Result<BlockContainer>> {
         return readWithQuorum(request, matcher)
             .timeout(Defaults.timeoutInternal, Mono.error(TimeoutException("Block not read $id")))
             .retryWhen(Retry.fixedDelay(3, Duration.ofMillis(200)))
-            .flatMap { blockbytes ->
-                val block = objectMapper.readValue(blockbytes, BlockJson::class.java) as BlockJson<TransactionRefJson>?
+            .flatMap { result ->
+                val block = objectMapper.readValue(result.data, BlockJson::class.java) as BlockJson<TransactionRefJson>?
                 if (block == null) {
-                    Mono.empty<BlockContainer>()
+                    Mono.empty()
                 } else {
-                    Mono.just(BlockContainer.from(block, blockbytes, "unknown"))
+                    Mono.just(
+                        Result(
+                            BlockContainer.from(block, result.data, "unknown"),
+                            result.upstreamId
+                        )
+                    )
                 }
             }
             .doOnNext { block ->
-                caches.cache(Caches.Tag.REQUESTED, block)
+                caches.cache(Caches.Tag.REQUESTED, block.data)
             }
     }
 
     /**
      * Read from an Upstream applying a Quorum specific for that request
      */
-    private fun readWithQuorum(request: JsonRpcRequest, matcher: Selector.Matcher = Selector.empty): Mono<ByteArray> {
+    private fun readWithQuorum(
+        request: JsonRpcRequest,
+        matcher: Selector.Matcher = Selector.empty
+    ): Mono<Result<ByteArray>> {
         return Mono.just(quorumReaderFactory)
             .map {
                 it.create(
@@ -185,7 +200,12 @@ class EthereumDirectReader(
             }.flatMap {
                 it.read(request)
             }.map {
-                it.value
+                Result(it.value, it.resolvedBy?.getId())
             }
     }
+
+    data class Result<T>(
+        val data: T,
+        val upstreamId: String?
+    )
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcResponse.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/JsonRpcResponse.kt
@@ -35,6 +35,9 @@ class JsonRpcResponse(
 
     constructor(result: ByteArray?, error: JsonRpcError?) : this(result, error, NumberId(0))
 
+    constructor(result: ByteArray?, error: JsonRpcError?, resolvedBy: String?) :
+        this(result, error, NumberId(0), null, resolvedBy)
+
     companion object {
         private val NULL_VALUE = "null".toByteArray()
 

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumCachingReaderSpec.groovy
@@ -69,7 +69,7 @@ class EthereumDirectReaderSpec extends Specification {
         then:
         StepVerifier.create(act)
                 .expectNextMatches { block ->
-                    block.hash.toHexWithPrefix() == hash1
+                    block.data.hash.toHexWithPrefix() == hash1
                 }
                 .expectComplete()
                 .verify(Duration.ofSeconds(1))
@@ -138,7 +138,7 @@ class EthereumDirectReaderSpec extends Specification {
         then:
         StepVerifier.create(act)
                 .expectNextMatches { block ->
-                    block.hash.toHexWithPrefix() == hash1
+                    block.data.hash.toHexWithPrefix() == hash1
                 }
                 .expectComplete()
                 .verify(Duration.ofSeconds(1))
@@ -174,7 +174,7 @@ class EthereumDirectReaderSpec extends Specification {
         then:
         StepVerifier.create(act)
                 .expectNextMatches { block ->
-                    block.hash.toHexWithPrefix() == hash1
+                    block.data.hash.toHexWithPrefix() == hash1
                 }
                 .expectComplete()
                 .verify(Duration.ofSeconds(1))
@@ -208,7 +208,7 @@ class EthereumDirectReaderSpec extends Specification {
         when:
         def act = reader.receiptReader.read(TransactionId.from(hash1))
             .block(Duration.ofSeconds(1))
-            .with { new String(it) }
+            .with { new String(it.data) }
         then:
         act == '{"blockHash":"0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5","blockNumber":"0x64","transactionHash":"0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5","logs":[]}'
     }
@@ -245,7 +245,7 @@ class EthereumDirectReaderSpec extends Specification {
         when:
         def act = reader.receiptReader.read(TransactionId.from(hash1))
                 .block(Duration.ofSeconds(1))
-                .with { new String(it) }
+                .with { new String(it.data) }
         then:
         act == '{"blockHash":"0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5","blockNumber":"0x64","transactionHash":"0x40d15edaff9acdabd2a1c96fd5f683b3300aad34e7015f34def3c56ba8a7ffb5","logs":[]}'
     }
@@ -302,7 +302,7 @@ class EthereumDirectReaderSpec extends Specification {
             }
         }
         when:
-        def act = reader.balanceReader.read(Address.from(address1))
+        def act = reader.balanceReader.read(Address.from(address1)).map {it.data}
         then:
         StepVerifier.create(act)
                 .expectNext(Wei.from("0x100"))
@@ -334,7 +334,7 @@ class EthereumDirectReaderSpec extends Specification {
             }
         }
         when:
-        def act = reader.balanceReader.read(Address.from(address1))
+        def act = reader.balanceReader.read(Address.from(address1)).map {it.data}
         then:
         StepVerifier.create(act)
                 .expectNext(Wei.from("0x100"))
@@ -379,7 +379,7 @@ class EthereumDirectReaderSpec extends Specification {
         then:
         StepVerifier.create(act)
                 .expectNextMatches { block ->
-                    block.hash.toHexWithPrefix() == hash1
+                    block.data.hash.toHexWithPrefix() == hash1
                 }
                 .expectComplete()
                 .verify(Duration.ofSeconds(1))
@@ -422,7 +422,7 @@ class EthereumDirectReaderSpec extends Specification {
         then:
         StepVerifier.create(act)
                 .expectNextMatches { block ->
-                    block.hash.toHexWithPrefix() == hash1
+                    block.data.hash.toHexWithPrefix() == hash1
                 }
                 .expectComplete()
                 .verify(Duration.ofSeconds(1))

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLocalReaderSpec.groovy
@@ -69,7 +69,9 @@ class EthereumLocalReaderSpec extends Specification {
             _ * blocksByIdAsCont() >> new EmptyReader<>()
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
-                1 * read(101L) >> Mono.just(TestingCommons.blockForEthereum(101L))
+                1 * read(101L) >> Mono.just(
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(101L), null)
+                )
             }
         }
         def methods = new DefaultEthereumMethods(Chain.ETHEREUM__MAINNET)
@@ -81,8 +83,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.length > 0
-            with(Global.objectMapper.readValue(it, BlockJson)) {
+            it.first.length > 0
+            with(Global.objectMapper.readValue(it.first, BlockJson)) {
                 number == 101
             }
         }
@@ -95,7 +97,9 @@ class EthereumLocalReaderSpec extends Specification {
             _ * blocksByIdAsCont() >> new EmptyReader<>()
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
-                1 * read(0L) >> Mono.just(TestingCommons.blockForEthereum(0L))
+                1 * read(0L) >> Mono.just(
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(0L), null)
+                )
             }
         }
         def methods = new DefaultEthereumMethods(Chain.ETHEREUM__MAINNET)
@@ -107,8 +111,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.length > 0
-            with(Global.objectMapper.readValue(it, BlockJson)) {
+            it.first.length > 0
+            with(Global.objectMapper.readValue(it.first, BlockJson)) {
                 number == 0
             }
         }
@@ -121,7 +125,9 @@ class EthereumLocalReaderSpec extends Specification {
             _ * blocksByIdAsCont() >> new EmptyReader<>()
             _ * txByHashAsCont() >> new EmptyReader<>()
             1 * blocksByHeightAsCont() >> Mock(Reader) {
-                1 * read(74735L) >> Mono.just(TestingCommons.blockForEthereum(74735L))
+                1 * read(74735L) >> Mono.just(
+                        new EthereumDirectReader.Result<>(TestingCommons.blockForEthereum(74735L), null)
+                )
             }
         }
         def methods = new DefaultEthereumMethods(Chain.ETHEREUM__MAINNET)
@@ -133,8 +139,8 @@ class EthereumLocalReaderSpec extends Specification {
         then:
         act != null
         with(act.block()) {
-            it.length > 0
-            with(Global.objectMapper.readValue(it, BlockJson)) {
+            it.first.length > 0
+            with(Global.objectMapper.readValue(it.first, BlockJson)) {
                 number == 74735
             }
         }

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ProduceLogsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/subscribe/ProduceLogsSpec.groovy
@@ -18,6 +18,7 @@ package io.emeraldpay.dshackle.upstream.ethereum.subscribe
 import io.emeraldpay.dshackle.data.BlockId
 import io.emeraldpay.dshackle.data.TxId
 import io.emeraldpay.dshackle.reader.Reader
+import io.emeraldpay.dshackle.upstream.ethereum.EthereumDirectReader
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 
@@ -38,7 +39,8 @@ class ProduceLogsSpec extends Specification {
                 '  }'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update = new ConnectBlockUpdates.Update(
@@ -61,7 +63,8 @@ class ProduceLogsSpec extends Specification {
         String receipt = 'null'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update = new ConnectBlockUpdates.Update(
@@ -107,7 +110,8 @@ class ProduceLogsSpec extends Specification {
                 '  }'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update = new ConnectBlockUpdates.Update(
@@ -153,7 +157,8 @@ class ProduceLogsSpec extends Specification {
                 '  }'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0x6c88df9d65ccc9351db65676c3581b29483e8dabb71c48ef7671c44b0d5568af")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update = new ConnectBlockUpdates.Update(
@@ -264,7 +269,8 @@ class ProduceLogsSpec extends Specification {
                 '  }'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0xb5e554178a94fd993111f2ae64cb708cb0899d7b5182024e70d5c468164a8bec")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0xb5e554178a94fd993111f2ae64cb708cb0899d7b5182024e70d5c468164a8bec")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update = new ConnectBlockUpdates.Update(
@@ -343,7 +349,8 @@ class ProduceLogsSpec extends Specification {
                 '  }'
 
         def receipts = Mock(Reader) {
-            1 * it.read(TxId.from("0xb5e554178a94fd993111f2ae64cb708cb0899d7b5182024e70d5c468164a8bec")) >> Mono.just(receipt.getBytes())
+            1 * it.read(TxId.from("0xb5e554178a94fd993111f2ae64cb708cb0899d7b5182024e70d5c468164a8bec")) >>
+                    Mono.just(new EthereumDirectReader.Result<>(receipt.getBytes(), null))
         }
         def producer = new ProduceLogs(receipts)
         def update1 = new ConnectBlockUpdates.Update(


### PR DESCRIPTION
Before that we received a multistream id as a response upstream id in the case of `LocalReader`. It's not always true. We can also get an upstreamId when we send a request direct through `DirectReader`. So we fix it.