### PR TITLE
Maximum value quorum for BroadcastReader

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/AlwaysQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/AlwaysQuorum.kt
@@ -16,7 +16,6 @@
  */
 package io.emeraldpay.dshackle.quorum
 
-import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcError
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcException
@@ -29,9 +28,6 @@ open class AlwaysQuorum : CallQuorum {
     private var rpcError: JsonRpcError? = null
     private var sig: ResponseSigner.Signature? = null
     private val resolvers = ArrayList<Upstream>()
-
-    override fun init(head: Head) {
-    }
 
     override fun isResolved(): Boolean {
         return resolved

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
@@ -16,28 +16,21 @@
  */
 package io.emeraldpay.dshackle.quorum
 
-import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.signature.ResponseSigner
 
-open class BroadcastQuorum(
-    val quorum: Int = 3
-) : CallQuorum, ValueAwareQuorum<String>(String::class.java) {
+open class BroadcastQuorum() : CallQuorum, ValueAwareQuorum<String>(String::class.java) {
 
     private var result: ByteArray? = null
     private var txid: String? = null
-    private var calls = 0
     private var sig: ResponseSigner.Signature? = null
 
-    override fun init(head: Head) {
-    }
-
     override fun isResolved(): Boolean {
-        return calls >= quorum && txid != null
+        return result != null
     }
 
     override fun isFailed(): Boolean {
-        return calls >= quorum && getError() != null
+        return result == null
     }
 
     override fun getResult(): ByteArray? {
@@ -54,12 +47,12 @@ open class BroadcastQuorum(
         signature: ResponseSigner.Signature?,
         upstream: Upstream
     ) {
-        calls++
         if (txid == null && responseValue != null) {
             txid = responseValue
             sig = signature
             result = response
         }
+        resolvers.add(upstream)
     }
 
     override fun recordError(
@@ -68,16 +61,9 @@ open class BroadcastQuorum(
         signature: ResponseSigner.Signature?,
         upstream: Upstream
     ) {
-        // can be "message: known transaction: TXID", "Transaction with the same hash was already imported" or "message: Nonce too low"
-        calls++
-        if (result == null) {
-            result = response
-            sig = signature
-        }
-        resolvers.add(upstream)
     }
 
     override fun toString(): String {
-        return "Quorum: Broadcast to $quorum upstreams"
+        return "Quorum: Broadcast to upstreams"
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
@@ -60,6 +60,7 @@ open class BroadcastQuorum() : CallQuorum, ValueAwareQuorum<String>(String::clas
         signature: ResponseSigner.Signature?,
         upstream: Upstream
     ) {
+        resolvers.add(upstream)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/BroadcastQuorum.kt
@@ -52,7 +52,6 @@ open class BroadcastQuorum() : CallQuorum, ValueAwareQuorum<String>(String::clas
             sig = signature
             result = response
         }
-        resolvers.add(upstream)
     }
 
     override fun recordError(

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/CallQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/CallQuorum.kt
@@ -16,16 +16,12 @@
  */
 package io.emeraldpay.dshackle.quorum
 
-import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcError
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcException
 import io.emeraldpay.dshackle.upstream.signature.ResponseSigner
 
 interface CallQuorum {
-
-    fun init(head: Head)
-
     fun isResolved(): Boolean
     fun isFailed(): Boolean
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
@@ -3,7 +3,6 @@ package io.emeraldpay.dshackle.quorum
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.signature.ResponseSigner
 import io.emeraldpay.etherjar.hex.HexQuantity
-import java.util.concurrent.atomic.AtomicReference
 
 class MaximumValueQuorum : CallQuorum, ValueAwareQuorum<String>(String::class.java) {
     private var max: Long? = null

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
@@ -1,0 +1,57 @@
+package io.emeraldpay.dshackle.quorum
+
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.signature.ResponseSigner
+import io.emeraldpay.etherjar.hex.HexQuantity
+import java.util.concurrent.atomic.AtomicReference
+
+class MaximumValueQuorum : CallQuorum, ValueAwareQuorum<String>(String::class.java) {
+    private val max: AtomicReference<Long?> = AtomicReference()
+    private var result: ByteArray? = null
+    private var sig: ResponseSigner.Signature? = null
+
+    override fun isResolved(): Boolean {
+        return result != null
+    }
+
+    override fun isFailed(): Boolean {
+        return result == null
+    }
+
+    override fun getResult(): ByteArray? {
+        return result
+    }
+
+    override fun getSignature(): ResponseSigner.Signature? {
+        return sig
+    }
+    override fun recordValue(
+        response: ByteArray,
+        responseValue: String?,
+        signature: ResponseSigner.Signature?,
+        upstream: Upstream
+    ) {
+        val value = responseValue?.let { str ->
+            HexQuantity.from(str).value.toLong()
+        }
+        if (value != null) {
+            max.getAndUpdate {
+                if (it == null || it < value) {
+                    sig = signature
+                    resolvers.clear()
+                    result = response
+                    value
+                } else {
+                    it
+                }
+            }
+        }
+    }
+
+    override fun recordError(
+        response: ByteArray?,
+        errorMessage: String?,
+        signature: ResponseSigner.Signature?,
+        upstream: Upstream
+    ) {}
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
@@ -6,7 +6,7 @@ import io.emeraldpay.etherjar.hex.HexQuantity
 import java.util.concurrent.atomic.AtomicReference
 
 class MaximumValueQuorum : CallQuorum, ValueAwareQuorum<String>(String::class.java) {
-    private val max: AtomicReference<Long?> = AtomicReference()
+    private var max: Long? = null
     private var result: ByteArray? = null
     private var sig: ResponseSigner.Signature? = null
 
@@ -35,7 +35,7 @@ class MaximumValueQuorum : CallQuorum, ValueAwareQuorum<String>(String::class.ja
             HexQuantity.from(str).value.toLong()
         }
         if (value != null) {
-            max.getAndUpdate {
+            max = max.let {
                 if (it == null || it < value) {
                     sig = signature
                     resolvers.clear()

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/MaximumValueQuorum.kt
@@ -52,5 +52,9 @@ class MaximumValueQuorum : CallQuorum, ValueAwareQuorum<String>(String::class.ja
         errorMessage: String?,
         signature: ResponseSigner.Signature?,
         upstream: Upstream
-    ) {}
+    ) {
+        if (max == null) {
+            resolvers.add(upstream)
+        }
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotLaggingQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotLaggingQuorum.kt
@@ -16,7 +16,6 @@
  */
 package io.emeraldpay.dshackle.quorum
 
-import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcError
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcException
@@ -35,9 +34,6 @@ class NotLaggingQuorum(val maxLag: Long = 0) : CallQuorum {
     private var rpcError: JsonRpcError? = null
     private var sig: ResponseSigner.Signature? = null
     private val resolvers = ArrayList<Upstream>()
-
-    override fun init(head: Head) {
-    }
 
     override fun isResolved(): Boolean {
         return !isFailed() && result.get() != null

--- a/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotNullQuorum.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/quorum/NotNullQuorum.kt
@@ -1,7 +1,6 @@
 package io.emeraldpay.dshackle.quorum
 
 import io.emeraldpay.dshackle.Global
-import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcError
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcException
@@ -14,9 +13,6 @@ class NotNullQuorum : CallQuorum {
     private val resolvers = ArrayList<Upstream>()
     private var allFailed = true
     private val seenUpstreams = HashSet<String>() // just to prevent calling retry upstreams in FilteredApis
-
-    override fun init(head: Head) {
-    }
 
     override fun isResolved(): Boolean = result != null
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/reader/RpcReaderFactory.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/reader/RpcReaderFactory.kt
@@ -62,8 +62,8 @@ interface RpcReaderFactory {
 
     class Default : RpcReaderFactory {
         override fun create(data: RpcReaderData): RpcReader {
-            if (data.method == "eth_sendRawTransaction") {
-                return BroadcastReader(data.multistream.getAll(), data.matcher, data.signer, data.tracer)
+            if (data.method == "eth_sendRawTransaction" || data.method == "eth_getTransactionCount") {
+                return BroadcastReader(data.multistream.getAll(), data.matcher, data.signer, data.quorum, data.tracer)
             }
             val apis = data.multistream.getApiSource(data.matcher)
             return QuorumRpcReader(apis, data.quorum, data.signer, data.tracer)

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -324,8 +324,6 @@ open class NativeCall(
                 .forLabels(Selector.convertToMatcher(request.selector))
 
             val callQuorum = availableMethods.createQuorumFor(method) // can be null in tests
-            callQuorum.init(upstream.getHead())
-
             // for NotLaggingQuorum it makes sense to select compatible upstreams before the call
             if (callQuorum is NotLaggingQuorum) {
                 val lag = callQuorum.maxLag

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
@@ -19,6 +19,7 @@ package io.emeraldpay.dshackle.upstream.calls
 import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.quorum.AlwaysQuorum
+import io.emeraldpay.dshackle.quorum.BroadcastQuorum
 import io.emeraldpay.dshackle.quorum.CallQuorum
 import io.emeraldpay.dshackle.quorum.MaximumValueQuorum
 import io.emeraldpay.dshackle.quorum.NotLaggingQuorum
@@ -200,6 +201,7 @@ class DefaultEthereumMethods(
                     "eth_getTransactionCount" -> MaximumValueQuorum()
                     "eth_getBalance" -> AlwaysQuorum()
                     "eth_blockNumber" -> NotLaggingQuorum(0)
+                    "eth_sendRawTransaction" -> BroadcastQuorum()
                     else -> AlwaysQuorum()
                 }
             }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
@@ -20,6 +20,7 @@ import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.quorum.AlwaysQuorum
 import io.emeraldpay.dshackle.quorum.CallQuorum
+import io.emeraldpay.dshackle.quorum.MaximumValueQuorum
 import io.emeraldpay.dshackle.quorum.NotLaggingQuorum
 import io.emeraldpay.dshackle.quorum.NotNullQuorum
 import io.emeraldpay.etherjar.rpc.RpcException
@@ -196,7 +197,7 @@ class DefaultEthereumMethods(
             possibleNotIndexedMethods.contains(method) -> NotNullQuorum()
             specialMethods.contains(method) -> {
                 when (method) {
-                    "eth_getTransactionCount" -> AlwaysQuorum()
+                    "eth_getTransactionCount" -> MaximumValueQuorum()
                     "eth_getBalance" -> AlwaysQuorum()
                     "eth_blockNumber" -> NotLaggingQuorum(0)
                     else -> AlwaysQuorum()

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/MaximumValueQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/MaximumValueQuorumSpec.groovy
@@ -71,7 +71,7 @@ class MaximumValueQuorumSpec extends Specification {
         !quorum.isResolved()
         quorum.isFailed()
         quorum.error == new JsonRpcException(10, "error3").error
-        quorum.resolvedBy.size() == 0
+        quorum.resolvedBy.size() == 3
     }
 
 }

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/MaximumValueQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/MaximumValueQuorumSpec.groovy
@@ -1,0 +1,77 @@
+package io.emeraldpay.dshackle.quorum
+
+import io.emeraldpay.dshackle.upstream.Upstream
+import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcException
+import spock.lang.Specification
+
+class MaximumValueQuorumSpec extends Specification {
+    def "selects maximum from 3 values"() {
+        setup:
+        def up = Mock(Upstream) {
+            getId() >> "id"
+        }
+        def up1 = Mock(Upstream) {
+            getId() >> "id1"
+        }
+        def up2 = Mock(Upstream) {
+            getId() >> "id2"
+        }
+        when:
+        def quorum = new MaximumValueQuorum()
+        quorum.record('"0x137"'.bytes, null, up)
+        quorum.record('"0x138"'.bytes, null, up1)
+        quorum.record('"0x139"'.bytes, null, up2)
+        then:
+        quorum.result == '"0x139"'.bytes
+        quorum.resolvedBy.size() == 1
+        quorum.isResolved()
+        quorum.resolvedBy.contains(up2)
+    }
+
+    def "selects maximum from 2 values and an error"() {
+        setup:
+        def up = Mock(Upstream) {
+            getId() >> "id"
+        }
+        def up1 = Mock(Upstream) {
+            getId() >> "id1"
+        }
+        def up2 = Mock(Upstream) {
+            getId() >> "id2"
+        }
+        when:
+        def quorum = new MaximumValueQuorum()
+        quorum.record('"0x137"'.bytes, null, up)
+        quorum.record('"0x138"'.bytes, null, up1)
+        quorum.record(new JsonRpcException(10, "error"), null, up2)
+        then:
+        quorum.result == '"0x138"'.bytes
+        quorum.isResolved()
+        quorum.resolvedBy.size() == 1
+        quorum.resolvedBy.contains(up1)
+    }
+
+    def "returns error is all error"() {
+        setup:
+        def up = Mock(Upstream) {
+            getId() >> "id"
+        }
+        def up1 = Mock(Upstream) {
+            getId() >> "id1"
+        }
+        def up2 = Mock(Upstream) {
+            getId() >> "id2"
+        }
+        when:
+        def quorum = new MaximumValueQuorum()
+        quorum.record(new JsonRpcException(10, "error1"), null, up)
+        quorum.record(new JsonRpcException(10, "error2"), null, up1)
+        quorum.record(new JsonRpcException(10, "error3"), null, up2)
+        then:
+        !quorum.isResolved()
+        quorum.isFailed()
+        quorum.error == new JsonRpcException(10, "error3").error
+        quorum.resolvedBy.size() == 0
+    }
+
+}

--- a/src/test/groovy/io/emeraldpay/dshackle/quorum/ValueAwareQuorumSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/quorum/ValueAwareQuorumSpec.groovy
@@ -78,11 +78,6 @@ class ValueAwareQuorumSpec extends Specification {
         }
 
         @Override
-        void init(@NotNull Head head) {
-
-        }
-
-        @Override
         boolean isResolved() {
             return false
         }


### PR DESCRIPTION
Fixes problem when we ask amount of transactions for user including mempool. Unfortunately, it's not always possible to propagate transaction to all nodes, so we need to ask all nodes and select maximum.