### PR TITLE
Fix archive detection

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumArchiveBlockNumberReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumArchiveBlockNumberReader.kt
@@ -1,10 +1,15 @@
 package io.emeraldpay.dshackle.upstream.ethereum
 
+import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.reader.JsonRpcReader
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcRequest
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcResponse
 import io.emeraldpay.etherjar.hex.HexQuantity
 import reactor.core.publisher.Mono
+
+private const val ARBITRUM_NITRO_BLOCK = "0x152DD47" // 22207815
+private const val OPTIMISM_BEDROCK_BLOCK = "0x645C277" // 105235063
+private const val EARLIEST_BLOCK = "0x2710" // 10000
 
 class EthereumArchiveBlockNumberReader(
     private val reader: JsonRpcReader,
@@ -19,4 +24,12 @@ class EthereumArchiveBlockNumberReader(
                         String(it).substring(3, it.size - 1).toLong(radix = 16) - 10_000, // this is definitely archive
                     ).toHex()
             }
+
+    fun readEarliestBlock(chain: Chain): Mono<String> {
+        return when (chain) {
+            Chain.ARBITRUM__MAINNET -> ARBITRUM_NITRO_BLOCK
+            Chain.OPTIMISM__MAINNET -> OPTIMISM_BEDROCK_BLOCK
+            else -> EARLIEST_BLOCK
+        }.run { Mono.just(this) }
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeRpcUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLikeRpcUpstream.kt
@@ -53,7 +53,7 @@ open class EthereumLikeRpcUpstream(
 ) : EthereumLikeUpstream(id, hash, options, role, targets, node, chainConfig), Lifecycle, Upstream, CachesEnabled {
     private val validator: EthereumUpstreamValidator = EthereumUpstreamValidator(chain, this, getOptions(), chainConfig.callLimitContract)
     protected val connector: EthereumConnector = connectorFactory.create(this, validator, chain, skipEnhance)
-    private val labelsDetector = EthereumLabelsDetector(this.getIngressReader())
+    private val labelsDetector = EthereumLabelsDetector(this.getIngressReader(), chain)
     private var hasLiveSubscriptionHead: AtomicBoolean = AtomicBoolean(false)
 
     private var validatorSubscription: Disposable? = null

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLabelsDetectorSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/ethereum/EthereumLabelsDetectorSpec.groovy
@@ -1,5 +1,6 @@
 package io.emeraldpay.dshackle.upstream.ethereum
 
+import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.reader.Reader
 import io.emeraldpay.dshackle.test.ApiReaderMock
 import io.emeraldpay.dshackle.test.TestingCommons
@@ -23,9 +24,10 @@ class EthereumLabelsDetectorSpec extends Specification {
                     answer("web3_clientVersion", [], response)
                     answer("eth_blockNumber", [], "0x10df3e5")
                     answer("eth_getBalance", ["0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0", "0x10dccd5"], "")
+                    answer("eth_getBalance", ["0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0", "0x2710"], "")
                 }
         )
-        def detector = new EthereumLabelsDetector(up.getIngressReader())
+        def detector = new EthereumLabelsDetector(up.getIngressReader(), Chain.ETHEREUM__MAINNET)
 
         when:
         def act = detector.detectLabels()
@@ -55,9 +57,11 @@ class EthereumLabelsDetectorSpec extends Specification {
                         Mono.just(new JsonRpcResponse("\"0x10df3e5\"".getBytes(), null))
                 1 * read(new JsonRpcRequest("eth_getBalance", ["0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0", "0x10dccd5"])) >>
                         Mono.error(new RuntimeException())
+                1 * read(new JsonRpcRequest("eth_getBalance", ["0x756F45E3FA69347A9A973A725E3C98bC4db0b5a0", "0x2710"])) >>
+                        Mono.just(new JsonRpcResponse("".getBytes(), null))
             }
         }
-        def detector = new EthereumLabelsDetector(up.getIngressReader())
+        def detector = new EthereumLabelsDetector(up.getIngressReader(), Chain.ETHEREUM__MAINNET)
         when:
         def act = detector.detectLabels()
         then:


### PR DESCRIPTION
Now we add for detection archive label a new check for the earliest block. There are also corner cases for arbitrum and optimism, for them we check nitro and bedrock block.