### PR TITLE
Make settings validation periodically

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/UpstreamChangeEvent.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/UpstreamChangeEvent.kt
@@ -59,6 +59,16 @@ data class UpstreamChangeEvent(
          * Upstream is removed (it still doesn't mean it wouldn't return again after some reconfiguration)
          */
         REMOVED,
+
+        /**
+         * Upstream is removed but not stopped due to upstream fatal settings error (it could return some reconfiguration)
+         */
+        FATAL_SETTINGS_ERROR_REMOVED,
+
+        /**
+         * Upstream is observed for state updates (it could be added later)
+         */
+        OBSERVED,
     }
 
     override fun setCaches(caches: Caches) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/BitcoinUpstreamCreator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/BitcoinUpstreamCreator.kt
@@ -10,7 +10,6 @@ import io.emeraldpay.dshackle.startup.QuorumForLabels
 import io.emeraldpay.dshackle.upstream.CallTargetsHolder
 import io.emeraldpay.dshackle.upstream.Head
 import io.emeraldpay.dshackle.upstream.MergedHead
-import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.bitcoin.BitcoinRpcHead
 import io.emeraldpay.dshackle.upstream.bitcoin.BitcoinRpcUpstream
 import io.emeraldpay.dshackle.upstream.bitcoin.BitcoinZMQHead
@@ -38,13 +37,13 @@ class BitcoinUpstreamCreator(
         chain: Chain,
         options: ChainOptions.Options,
         chainConf: ChainsConfig.ChainConfig,
-    ): Upstream? {
+    ): UpstreamCreationData {
         val config = upstreamsConfig.cast(UpstreamsConfig.BitcoinConnection::class.java)
         val conn = config.connection!!
         val httpFactory = genericConnectorFactoryCreator.buildHttpFactory(conn.rpc)
         if (httpFactory == null) {
             log.warn("Upstream doesn't have API configuration")
-            return null
+            return UpstreamCreationData.default()
         }
         val directApi = httpFactory.create(config.id, chain)
         val esplora = conn.esplora?.let { endpoint ->
@@ -74,6 +73,6 @@ class BitcoinUpstreamCreator(
             methods, esplora, chainConf,
         )
         upstream.start()
-        return upstream
+        return UpstreamCreationData(upstream, true)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/EthereumUpstreamCreator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/EthereumUpstreamCreator.kt
@@ -6,7 +6,6 @@ import io.emeraldpay.dshackle.config.IndexConfig
 import io.emeraldpay.dshackle.config.UpstreamsConfig
 import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.upstream.CallTargetsHolder
-import io.emeraldpay.dshackle.upstream.Upstream
 import org.springframework.stereotype.Component
 
 @Component
@@ -22,7 +21,7 @@ class EthereumUpstreamCreator(
         chain: Chain,
         options: ChainOptions.Options,
         chainConf: ChainsConfig.ChainConfig,
-    ): Upstream? {
+    ): UpstreamCreationData {
         var rating = 0
         val connection = if (upstreamsConfig.connection is UpstreamsConfig.EthereumPosConnection) {
             val posConn = upstreamsConfig.cast(UpstreamsConfig.EthereumPosConnection::class.java)

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/UpstreamCreator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/UpstreamCreator.kt
@@ -7,7 +7,6 @@ import io.emeraldpay.dshackle.config.IndexConfig
 import io.emeraldpay.dshackle.config.UpstreamsConfig
 import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.upstream.CallTargetsHolder
-import io.emeraldpay.dshackle.upstream.Upstream
 import io.emeraldpay.dshackle.upstream.calls.CallMethods
 import io.emeraldpay.dshackle.upstream.calls.ManagedCallMethods
 import org.slf4j.Logger
@@ -23,7 +22,7 @@ abstract class UpstreamCreator(
     fun createUpstream(
         upstreamsConfig: UpstreamsConfig.Upstream<*>,
         defaultOptions: Map<Chain, ChainOptions.PartialOptions>,
-    ): Upstream? {
+    ): UpstreamCreationData {
         val chain = Global.chainById(upstreamsConfig.chain)
         if (chain == Chain.UNSPECIFIED) {
             throw IllegalArgumentException("Chain is unknown: ${upstreamsConfig.chain}")
@@ -42,7 +41,7 @@ abstract class UpstreamCreator(
         chain: Chain,
         options: ChainOptions.Options,
         chainConf: ChainsConfig.ChainConfig,
-    ): Upstream?
+    ): UpstreamCreationData
 
     protected fun buildMethods(config: UpstreamsConfig.Upstream<*>, chain: Chain): CallMethods {
         return if (config.methods != null || config.methodGroups != null) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/UpstreamFactory.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/configure/UpstreamFactory.kt
@@ -7,6 +7,15 @@ import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.upstream.Upstream
 import org.springframework.stereotype.Component
 
+data class UpstreamCreationData(
+    val upstream: Upstream?,
+    val isValid: Boolean,
+) {
+    companion object {
+        fun default() = UpstreamCreationData(null, false)
+    }
+}
+
 @Component
 class UpstreamFactory(
     private val genericUpstreamCreator: GenericUpstreamCreator,
@@ -18,7 +27,7 @@ class UpstreamFactory(
         type: BlockchainType,
         upstreamsConfig: UpstreamsConfig.Upstream<*>,
         defaultOptions: Map<Chain, ChainOptions.PartialOptions>,
-    ): Upstream? {
+    ): UpstreamCreationData {
         return when (type) {
             BlockchainType.ETHEREUM -> ethereumUpstreamCreator.createUpstream(upstreamsConfig, defaultOptions)
             BlockchainType.BITCOIN -> bitcoinUpstreamCreator.createUpstream(upstreamsConfig, defaultOptions)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -8,6 +8,7 @@ import io.emeraldpay.dshackle.foundation.ChainOptions
 import io.emeraldpay.dshackle.reader.JsonRpcReader
 import io.emeraldpay.dshackle.startup.QuorumForLabels
 import io.emeraldpay.dshackle.startup.UpstreamChangeEvent
+import io.emeraldpay.dshackle.startup.UpstreamChangeEvent.ChangeType.UPDATED
 import io.emeraldpay.dshackle.upstream.Capability
 import io.emeraldpay.dshackle.upstream.DefaultUpstream
 import io.emeraldpay.dshackle.upstream.Head
@@ -56,6 +57,9 @@ open class GenericUpstream(
     private val labelsDetector = labelsDetectorBuilder(chain, this.getIngressReader())
 
     private val lowerBoundBlockDetector = lowerBoundBlockDetectorBuilder(chain, this)
+
+    private val started = AtomicBoolean(false)
+    private val isUpstreamValid = AtomicBoolean(false)
 
     override fun getHead(): Head {
         return connector.getHead()
@@ -108,44 +112,55 @@ open class GenericUpstream(
                     return
                 }
                 ValidateUpstreamSettingsResult.UPSTREAM_SETTINGS_ERROR -> {
-                    validateUpstreamSettings()
+                    log.warn("Non fatal upstream settings error, continue validation...")
                 }
-                else -> {
+                ValidateUpstreamSettingsResult.UPSTREAM_VALID -> {
+                    isUpstreamValid.set(true)
                     upstreamStart()
                 }
             }
+            validateUpstreamSettings()
         } else {
+            isUpstreamValid.set(true)
             upstreamStart()
         }
+
+        started.set(true)
     }
 
     private fun validateUpstreamSettings() {
         if (validator != null) {
             validationSettingsSubscription = Flux.interval(
-                Duration.ofSeconds(10),
                 Duration.ofSeconds(20),
             ).flatMap {
                 validator.validateUpstreamSettings()
-            }.subscribe {
-                when (it) {
-                    ValidateUpstreamSettingsResult.UPSTREAM_FATAL_SETTINGS_ERROR -> {
-                        connector.stop()
-                        disposeValidationSettingsSubscription()
-                    }
+            }
+                .distinctUntilChanged()
+                .subscribe {
+                    when (it) {
+                        ValidateUpstreamSettingsResult.UPSTREAM_FATAL_SETTINGS_ERROR -> {
+                            if (isUpstreamValid.get()) {
+                                log.warn("There is a fatal error after upstream settings validation, removing ${getId()}...")
+                                partialStop()
+                                sendUpstreamStateEvent(UpstreamChangeEvent.ChangeType.FATAL_SETTINGS_ERROR_REMOVED)
+                            }
+                            isUpstreamValid.set(false)
+                        }
 
-                    ValidateUpstreamSettingsResult.UPSTREAM_VALID -> {
-                        upstreamStart()
-                        stateEventStream.emitNext(
-                            UpstreamChangeEvent(chain, this, UpstreamChangeEvent.ChangeType.ADDED),
-                        ) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
-                        disposeValidationSettingsSubscription()
-                    }
+                        ValidateUpstreamSettingsResult.UPSTREAM_VALID -> {
+                            if (!isUpstreamValid.get()) {
+                                log.warn("Upstream ${getId()} is now valid, adding to the multistream...")
+                                upstreamStart()
+                                sendUpstreamStateEvent(UpstreamChangeEvent.ChangeType.ADDED)
+                            }
+                            isUpstreamValid.set(true)
+                        }
 
-                    else -> {
-                        log.warn("Continue validation of upstream ${getId()}")
+                        else -> {
+                            log.warn("Continue validation of upstream ${getId()}")
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -165,9 +180,7 @@ open class GenericUpstream(
         }
         livenessSubscription = connector.hasLiveSubscriptionHead().subscribe({
             hasLiveSubscriptionHead.set(it)
-            stateEventStream.emitNext(
-                UpstreamChangeEvent(chain, this, UpstreamChangeEvent.ChangeType.UPDATED),
-            ) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
+            sendUpstreamStateEvent(UPDATED)
         }, {
             log.debug("Error while checking live subscription for ${getId()}", it)
         },)
@@ -177,19 +190,19 @@ open class GenericUpstream(
     }
 
     override fun stop() {
+        validationSettingsSubscription?.dispose()
+        validationSettingsSubscription = null
+        connector.stop()
+    }
+
+    private fun partialStop() {
         validatorSubscription?.dispose()
         validatorSubscription = null
         livenessSubscription?.dispose()
         livenessSubscription = null
         lowerBlockDetectorSubscription?.dispose()
         lowerBlockDetectorSubscription = null
-        disposeValidationSettingsSubscription()
-        connector.stop()
-    }
-
-    private fun disposeValidationSettingsSubscription() {
-        validationSettingsSubscription?.dispose()
-        validationSettingsSubscription = null
+        connector.getHead().stop()
     }
 
     private fun updateLabels(label: Pair<String, String>) {
@@ -202,9 +215,7 @@ open class GenericUpstream(
     private fun detectLowerBlock() {
         lowerBlockDetectorSubscription = lowerBoundBlockDetector.lowerBlock()
             .subscribe {
-                stateEventStream.emitNext(
-                    UpstreamChangeEvent(chain, this, UpstreamChangeEvent.ChangeType.UPDATED),
-                ) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
+                sendUpstreamStateEvent(UPDATED)
             }
     }
 
@@ -212,5 +223,13 @@ open class GenericUpstream(
         return connector.getIngressSubscription()
     }
 
-    override fun isRunning() = connector.isRunning() && validationSettingsSubscription == null
+    override fun isRunning() = connector.isRunning() || started.get()
+
+    fun isValid(): Boolean = isUpstreamValid.get()
+
+    private fun sendUpstreamStateEvent(eventType: UpstreamChangeEvent.ChangeType) {
+        stateEventStream.emitNext(
+            UpstreamChangeEvent(chain, this, eventType),
+        ) { _, res -> res == Sinks.EmitResult.FAIL_NON_SERIALIZED }
+    }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/generic/GenericUpstream.kt
@@ -190,9 +190,11 @@ open class GenericUpstream(
     }
 
     override fun stop() {
+        partialStop()
         validationSettingsSubscription?.dispose()
         validationSettingsSubscription = null
         connector.stop()
+        started.set(false)
     }
 
     private fun partialStop() {


### PR DESCRIPTION
Now we make the upstream settings validation periodically. We want to remove and add upstreams according to the result of this validation. Because of that we must change a bit the current logic:

- We've added two more upstream event types: `FATAL_SETTINGS_ERROR_REMOVED` and `OBSERVED`. We use `FATAL_SETTINGS_ERROR_REMOVED` event type to remove an invalid upstream but not stop it and `OBSERVED`  to add an upstream to the observation of its states.
- On startup we perform the settings validation: 1) if we get an fatal error we don't create such upstream, 2) if we get a non fatal error we add this upstream to the observation, create it but not start until we get a valid status of the validation 3) if we get a valid result we just start an upstream.
- After an upstream has started we perform the validation periodically (each 20 seconds). 1) if we get a fatal error we remove an upstream from multistream but not stop it completely, only partial, what means to keep on validation checks but dispose all its internal subscriptions and stop its head 2) if we get a valid result we return this upstream to multistream and start its heads and all subs.