### PR TITLE
adds zksync-sepolia support

### DIFF
--- a/docs/04-upstream-config.adoc
+++ b/docs/04-upstream-config.adoc
@@ -122,6 +122,7 @@ Currently, dshackle supports next chains (should be used as chain names in confi
 ** binance (bsc, bnb-smart-chain)
 ** bsc-testnet
 ** zksync
+** zksync-sepolia
 ** zksync-testnet
 ** polygon-zkevm
 ** polygon-zkevm-testnet

--- a/foundation/src/main/resources/chains.yaml
+++ b/foundation/src/main/resources/chains.yaml
@@ -264,7 +264,7 @@ chain-settings:
         - id: Sepolia
           priority: 1
           code: ZKS_SEPOLIA
-          grpcId: 10036
+          grpcId: 10046
           chain-id: 0x12c
           short-names: [zksync-sepolia]
     - id: base

--- a/foundation/src/main/resources/chains.yaml
+++ b/foundation/src/main/resources/chains.yaml
@@ -261,6 +261,12 @@ chain-settings:
           grpcId: 10012
           chain-id: 0x118
           short-names: [zksync-testnet]
+        - id: Sepolia
+          priority: 1
+          code: ZKS_SEPOLIA
+          grpcId: 10036
+          chain-id: 0x12c
+          short-names: [zksync-sepolia]
     - id: base
       label: Base
       type: eth


### PR DESCRIPTION
Zksync Goerli is EOL in Jan 24 as per their [announcment](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/228)

This PR adds zksync-sepolia support to chains.yaml