### PR TITLE
Improve solana lower bound detection

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/LowerBoundBlockDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/LowerBoundBlockDetector.kt
@@ -4,6 +4,7 @@ import io.emeraldpay.dshackle.Chain
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,6 +33,7 @@ abstract class LowerBoundBlockDetector(
             .flatMap {
                 notProcessing.set(false)
                 lowerBlockDetect()
+                    .switchIfEmpty { Mono.just(LowerBlockData.default()) } // just to trigger onNext event
             }
             .doOnNext {
                 notProcessing.set(true)

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/LowerBoundBlockDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/LowerBoundBlockDetector.kt
@@ -33,6 +33,7 @@ abstract class LowerBoundBlockDetector(
             .flatMap {
                 notProcessing.set(false)
                 lowerBlockDetect()
+                    .onErrorResume { Mono.just(LowerBlockData.default()) }
                     .switchIfEmpty { Mono.just(LowerBlockData.default()) } // just to trigger onNext event
             }
             .doOnNext {

--- a/src/test/kotlin/io/emeraldpay/dshackle/upstream/RecursiveLowerBoundBlockDetectorTest.kt
+++ b/src/test/kotlin/io/emeraldpay/dshackle/upstream/RecursiveLowerBoundBlockDetectorTest.kt
@@ -6,7 +6,7 @@ import io.emeraldpay.dshackle.upstream.ethereum.EthereumLowerBoundBlockDetector
 import io.emeraldpay.dshackle.upstream.polkadot.PolkadotLowerBoundBlockDetector
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcRequest
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcResponse
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -42,7 +42,7 @@ class RecursiveLowerBoundBlockDetectorTest {
             .thenCancel()
             .verify(Duration.ofSeconds(3))
 
-        Assertions.assertEquals(LowerBoundBlockDetector.LowerBlockData(17964844L), detector.getCurrentLowerBlock())
+        assertEquals(17964844L, detector.getCurrentLowerBlock().blockNumber)
     }
 
     @ParameterizedTest
@@ -68,7 +68,7 @@ class RecursiveLowerBoundBlockDetectorTest {
             .thenCancel()
             .verify(Duration.ofSeconds(3))
 
-        Assertions.assertEquals(LowerBoundBlockDetector.LowerBlockData(1), detector.getCurrentLowerBlock())
+        assertEquals(1, detector.getCurrentLowerBlock().blockNumber)
     }
 
     companion object {


### PR DESCRIPTION
- there is no need to use `getBlocks` method in lower bound detection since `getFirstAvailableBlock` returns the slot of the lowest confirmed block
- add `switchIfEmpty` operator to prevent getting stuck in lower bound detection
- there is no need to retry solana errors infinitely