### PR TITLE
Remove NativeCall sort

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/NativeCall.kt
@@ -81,7 +81,6 @@ open class NativeCall(
 
     open fun nativeCall(requestMono: Mono<BlockchainOuterClass.NativeCallRequest>): Flux<BlockchainOuterClass.NativeCallReplyItem> {
         return nativeCallResult(requestMono)
-            .sort { o1, o2 -> o1.id - o2.id }
             .flatMapSequential(this::processCallResult)
             .onErrorResume(this::processException)
     }


### PR DESCRIPTION
Because if this `sort` we can have an issue when all requests get stuck due to there are no any more connections and `Flux.sort` waits for all elements and only then carries out sorting. In this case we get a specific deadlock - remain requests are added to the queue and they wait for a connection, but `sort` at the same time wants all elements.
So we can freely remove it because we already have a sorting algorithm on our dproxy side.