### PR TITLE
Fix proxy newHeads sub

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
@@ -139,7 +139,12 @@ class WebsocketHandler(
                     val responses = nativeSubscribe
                         .subscribe(blockchain, methodParams.first, methodParams.second, io.emeraldpay.dshackle.upstream.Selector.empty)
                         .map { event ->
-                            WsSubscriptionResponse(params = WsSubscriptionData(event, subscriptionId))
+                            val data = if (event is ByteArray) {
+                                Global.objectMapper.readTree(event)
+                            } else {
+                                event
+                            }
+                            WsSubscriptionResponse(params = WsSubscriptionData(data, subscriptionId))
                         }
                         .takeUntilOther(currentControl.asMono())
                     Flux.concat(Mono.just(start), responses)


### PR DESCRIPTION
Jackson serializes byte array in the base64 format, that's why our proxy `newHeads` sub worked incorrectly.