### PR TITLE
Update NEAR methods list

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultNearMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/DefaultNearMethods.kt
@@ -9,7 +9,6 @@ import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 class DefaultNearMethods : CallMethods {
 
     private val all = setOf(
-        "view_access_key",
         "query",
         "EXPERIMENTAL_changes",
         "block",
@@ -25,8 +24,7 @@ class DefaultNearMethods : CallMethods {
     )
 
     private val add = setOf(
-        "broadcast_tx_async",
-        "broadcast_tx_commit",
+        "send_tx",
     )
 
     private val allowedMethods: Set<String> = all + add


### PR DESCRIPTION
Add send_tx method https://docs.near.org/api/rpc/transactions 

Remove broadcast_tx_* deprecated methods https://docs.near.org/api/rpc/transactions#send-transaction-async

Remove view_access_key method (it's not a method, it's a query method option) https://docs.near.org/api/rpc/access-keys#view-access-key