### PR TITLE
dshackle: Fix websocket ping frames handling

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
@@ -231,7 +231,7 @@ open class WsConnectionImpl(
             }
             .websocket(
                 WebsocketClientSpec.builder()
-                    .handlePing(true)
+                    .handlePing(false)
                     .compress(false)
                     .maxFramePayloadLength(frameSize)
                     .build(),


### PR DESCRIPTION
true value requires custom handlers for web socket PING frames (which causes failures) false will auto send PONG frames

https://projectreactor.io/docs/netty/1.0.22/api/index.html?reactor/netty/http/websocket/WebsocketSpec.Builder.html