### PR TITLE
Track client nodes versions

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/UpstreamSettingsDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/UpstreamSettingsDetector.kt
@@ -77,7 +77,7 @@ abstract class BasicEthUpstreamSettingsDetector(
         val firstSlash = client.indexOf("/")
         val secondSlash = client.indexOf("/", firstSlash + 1)
         if (firstSlash == -1 || secondSlash == -1 || secondSlash < firstSlash) {
-            return null
+            return node.asText()
         }
         return client.substring(firstSlash + 1, secondSlash)
     }


### PR DESCRIPTION
Track client nodes versions also in case of bad parsing
Example:
filecoin i eth-like chain, but for example https://node.filutils.com/rpc/v1 node for request "web3_clientVersion" return "1.26.2+mainnet+git.464a1e856.dirty" version, but we expected "Geth/v10.0.0/drpc"