### PR TITLE
Add user-friendly verification instructions to LogIndexValidator error messages

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/LogIndexValidator.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/LogIndexValidator.kt
@@ -322,7 +322,9 @@ class LogIndexValidator(
                 "Node ${upstream.getId()} uses LOCAL logIndex instead of GLOBAL. " +
                     "First tx ($firstTxHash) has ${firstTxLogs.size()} logs (indices 0-$firstTxLastLogIndex), " +
                     "but second tx ($secondTxHash) starts at logIndex=0 instead of $expectedSecondTxStart. " +
-                    "This indicates Erigon bug with incorrect logIndex numbering.",
+                    "This indicates Erigon bug with incorrect logIndex numbering. " +
+                    "TO VERIFY: Send 'eth_getTransactionReceipt' for tx $secondTxHash to your RPC node " +
+                    "and check that logIndex is NOT zero. Then compare with the same request to a public RPC.",
             )
             return ValidateUpstreamSettingsResult.UPSTREAM_FATAL_SETTINGS_ERROR
         }
@@ -332,7 +334,9 @@ class LogIndexValidator(
             log.error(
                 "Node ${upstream.getId()} has non-continuous logIndex between transactions $firstTxHash and $secondTxHash: " +
                     "second transaction starts at $secondTxFirstLogIndex, expected $expectedSecondTxStart. " +
-                    "This indicates missing or incorrectly numbered logs.",
+                    "This indicates missing or incorrectly numbered logs. " +
+                    "TO VERIFY: Send 'eth_getTransactionReceipt' for both txs ($firstTxHash and $secondTxHash) " +
+                    "to your RPC node and check logIndex continuity. Compare with a public RPC.",
             )
             return ValidateUpstreamSettingsResult.UPSTREAM_FATAL_SETTINGS_ERROR
         }


### PR DESCRIPTION
## Summary
- Enhanced error messages in LogIndexValidator with clear instructions for users to verify the logIndex issue
- Added specific RPC commands that users can run to diagnose the problem

## Changes
- Updated error messages when detecting LOCAL vs GLOBAL logIndex numbering bug
- Added instructions to use `eth_getTransactionReceipt` to verify the issue
- Suggested comparing results with public RPC endpoints for confirmation

## Why this change?
Users were seeing error messages about logIndex validation failures but didn't know how to verify or investigate the issue. Now they have clear, actionable steps to diagnose the problem.