### PR TITLE
Allow unescaped control chars in JSON responses from upstreams

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/ResponseParser.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/rpcclient/ResponseParser.kt
@@ -32,7 +32,15 @@ abstract class ResponseParser<T> {
         private val log = LoggerFactory.getLogger(ResponseParser::class.java)
     }
 
-    private val jsonFactory = JsonFactory()
+    // Some upstreams (e.g. Moca's Tendermint EVM) embed raw control characters
+    // such as LF inside JSON string values (notably in `web3_clientVersion`
+    // results). Default Jackson rejects those with "Illegal unquoted character"
+    // before the response ever reaches the upstream-settings detector, so we
+    // relax just this one rule at the response-parsing layer to keep the
+    // payload flowing.
+    private val jsonFactory = JsonFactory().apply {
+        enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS)
+    }
 
     abstract fun build(state: Preparsed): T
 

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/rpcclient/ResponseRpcParserSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/rpcclient/ResponseRpcParserSpec.groovy
@@ -235,4 +235,18 @@ class ResponseRpcParserSpec extends Specification {
         !act.hasResult()
     }
 
+    // Regression: Moca's Tendermint EVM returns a web3_clientVersion result
+    // that contains a raw, unescaped LF (CTRL-CHAR, code 10) inside the JSON
+    // string. Default Jackson rejects that with "Illegal unquoted character",
+    // which used to break upstream node-type detection.
+    def "Parse string response with unescaped control chars"() {
+        setup:
+        def json = '{"jsonrpc":"2.0","id":1,"result":"Version dev ()\nCompiled at  using Go go1.23.11 (amd64)"}'
+        when:
+        def act = parser.parse(json.getBytes("UTF-8"))
+        then:
+        act.error == null
+        new String(act.result) == '"Version dev ()\nCompiled at  using Go go1.23.11 (amd64)"'
+    }
+
 }


### PR DESCRIPTION
## Summary
This change relaxes JSON parsing to accept unescaped control characters (like line feeds) in JSON string values, which some upstream nodes (notably Moca's Tendermint EVM) embed in responses like `web3_clientVersion`. Previously, Jackson's default strict parsing would reject these with "Illegal unquoted character" errors, breaking upstream node-type detection.

## Key Changes
- **ResponseParser.kt**: Enabled `JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS` on the JsonFactory to permit raw control characters within JSON strings while maintaining overall JSON structure validation
- **ResponseRpcParserSpec.groovy**: Added regression test case verifying that responses with unescaped LF characters (code 10) in string values are parsed successfully

## Implementation Details
The fix is applied at the response-parsing layer to ensure payloads flow through to upstream-settings detection even when they contain these non-standard but recoverable JSON formatting issues. The relaxed parsing is narrowly scoped to only allow unquoted control characters, preserving validation of the overall JSON structure.

https://claude.ai/code/session_01XXyRFdKFzMy4WE4bSKqubg