### PR TITLE
Mark 'state is not available' as non-retryable in proof lower bound detector

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundProofDetector.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/EthereumLowerBoundProofDetector.kt
@@ -31,6 +31,7 @@ class EthereumLowerBoundProofDetector(
             "invalid block height", // hyperliquid
             "not supported",
             "evm module does not exist on height",
+            "state is not available", // opbnb / bsc — eth_getProof on pruned state
         )
     }
 


### PR DESCRIPTION
## Summary
- opBNB (BSC-derived) returns `state is not available` from `eth_getProof` on pruned state. The proof detector's `NO_PROOF_ERRORS` did not include this string, so `RecursiveLowerBound.retrySpec` kept retrying indefinitely (Long.MAX_VALUE retries with exponential backoff up to 3 min) and emitted the self-reporting warning:
  ```
  WARN i.e.d.u.l.detector.RecursiveLowerBound : There are too much retries to calculate <block> lower bound of upstream PROOF, block <opbnb-upstream> probably this error with message `state is not available` is not retryable, please report it to dshackle devs
  ```
- The same string is already in `EthereumLowerBoundStateDetector.stateErrors` (with the comment "bsc also can return this error along with header not found") — opBNB inherits BSC error messages, so the proof detector should treat it the same way.
- Same class of fix as #662 ("add not retryable error to lower bound proof detector") and #799.
