### PR TITLE
Implement graceful shutdown coordination for service lifecycle

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
@@ -56,7 +56,6 @@ class GracefulShutdown(
     }
 
     private val shuttingDown = AtomicBoolean(false)
-    private val drainComplete = AtomicBoolean(false)
     private val inFlight = AtomicInteger(0)
 
     // Replay sink so subscribers that are created after shutdown is signaled also receive the cancel.
@@ -153,7 +152,6 @@ class GracefulShutdown(
 
         // Phase 2: wait for short-lived calls to finish.
         val drained = awaitDrain(drainTimeoutSeconds * 1000)
-        drainComplete.set(true)
         if (drained) {
             log.info("All in-flight requests completed within drain window")
         } else {

--- a/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
@@ -53,7 +53,6 @@ class GracefulShutdown(
 
     companion object {
         private val log = LoggerFactory.getLogger(GracefulShutdown::class.java)
-        private val TRACK_TOKEN = Any()
     }
 
     private val shuttingDown = AtomicBoolean(false)
@@ -105,23 +104,17 @@ class GracefulShutdown(
     }
 
     /** Wraps a Mono so the call is counted as in-flight while it executes. */
-    fun <T> trackMono(source: Mono<T>): Mono<T> {
-        return Mono.using(
-            { beginRequest(); TRACK_TOKEN },
-            { _ -> source },
-            { _ -> endRequest() },
-            true,
-        )
+    fun <T : Any> trackMono(source: Mono<T>): Mono<T> {
+        return source
+            .doOnSubscribe { beginRequest() }
+            .doFinally { endRequest() }
     }
 
     /** Wraps a Flux so the call is counted as in-flight while it executes. */
-    fun <T> trackFlux(source: Flux<T>): Flux<T> {
-        return Flux.using(
-            { beginRequest(); TRACK_TOKEN },
-            { _ -> source },
-            { _ -> endRequest() },
-            true,
-        )
+    fun <T : Any> trackFlux(source: Flux<T>): Flux<T> {
+        return source
+            .doOnSubscribe { beginRequest() }
+            .doFinally { endRequest() }
     }
 
     private fun awaitDrain(timeoutMillis: Long): Boolean {

--- a/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
@@ -40,6 +40,12 @@ import java.util.concurrent.atomic.AtomicInteger
  *   6. Force-close any still-active inbound servers.
  *   7. Allow Spring's normal `@PreDestroy` lifecycle (upstream connections, log flushing)
  *      to run for the remaining beans.
+ *
+ * Shutdown is triggered from two places (both idempotent via [shuttingDown]):
+ *   - A JVM shutdown hook registered in [registerJvmShutdownHook] — fires reliably on
+ *     SIGINT (Ctrl+C) and SIGTERM, regardless of Spring quirks.
+ *   - A [ContextClosedEvent] listener — fires when the application context is closed
+ *     programmatically (e.g. from tests).
  */
 @Service
 class GracefulShutdown(
@@ -129,7 +135,11 @@ class GracefulShutdown(
         return inFlight.get() == 0
     }
 
-    override fun onApplicationEvent(event: ContextClosedEvent) {
+    /**
+     * Idempotent: runs the full shutdown orchestration on the first call only.
+     * Safe to call from multiple paths (JVM hook, ContextClosedEvent listener, tests).
+     */
+    fun triggerShutdown() {
         if (!shuttingDown.compareAndSet(false, true)) {
             return
         }
@@ -167,6 +177,14 @@ class GracefulShutdown(
         runHooks(forceCloseHooks)
 
         log.info("Graceful shutdown coordinator finished; handing off to bean destruction")
+    }
+
+    /**
+     * Backstop for programmatic context closes (tests, embedded use). The JVM shutdown
+     * hook registered in `main()` is the primary trigger for SIGINT/SIGTERM.
+     */
+    override fun onApplicationEvent(event: ContextClosedEvent) {
+        triggerShutdown()
     }
 
     private fun runHooks(hooks: List<ShutdownHook>) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GracefulShutdown.kt
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2025 EmeraldPay, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.emeraldpay.dshackle
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextClosedEvent
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Coordinates graceful shutdown of the service.
+ *
+ * Industry-standard load-balancer-friendly sequence:
+ *   1. Mark the instance unhealthy so the load balancer stops routing new traffic.
+ *   2. Sleep for [healthGraceSeconds] to give the load balancer time to notice.
+ *   3. Stop accepting new connections on inbound servers (gRPC, HTTP/WS proxy).
+ *   4. Signal long-running streams (subscriptions) to terminate gracefully.
+ *   5. Wait up to [drainTimeoutSeconds] for in-flight request/response calls to complete.
+ *   6. Force-close any still-active inbound servers.
+ *   7. Allow Spring's normal `@PreDestroy` lifecycle (upstream connections, log flushing)
+ *      to run for the remaining beans.
+ */
+@Service
+class GracefulShutdown(
+    @Value("\${dshackle.shutdown.health-grace-seconds:5}")
+    private val healthGraceSeconds: Long,
+    @Value("\${dshackle.shutdown.drain-timeout-seconds:30}")
+    private val drainTimeoutSeconds: Long,
+    @Value("\${dshackle.shutdown.force-timeout-seconds:10}")
+    private val forceTimeoutSeconds: Long,
+) : ApplicationListener<ContextClosedEvent>, Ordered {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(GracefulShutdown::class.java)
+        private val TRACK_TOKEN = Any()
+    }
+
+    private val shuttingDown = AtomicBoolean(false)
+    private val drainComplete = AtomicBoolean(false)
+    private val inFlight = AtomicInteger(0)
+
+    // Replay sink so subscribers that are created after shutdown is signaled also receive the cancel.
+    private val streamsCancel: Sinks.Many<Boolean> = Sinks.many().replay().all()
+
+    private val stopAcceptingHooks: MutableList<ShutdownHook> = CopyOnWriteArrayList()
+    private val forceCloseHooks: MutableList<ShutdownHook> = CopyOnWriteArrayList()
+
+    fun isShuttingDown(): Boolean = shuttingDown.get()
+
+    fun inFlightCount(): Int = inFlight.get()
+
+    fun drainTimeoutSeconds(): Long = drainTimeoutSeconds
+
+    fun forceTimeoutSeconds(): Long = forceTimeoutSeconds
+
+    /**
+     * Emits a value when the service is shutting down. Long-running streams
+     * (e.g. gRPC subscriptions) should `takeUntilOther(streamsCancelSignal())`
+     * to terminate cleanly when shutdown begins.
+     */
+    fun streamsCancelSignal(): Mono<Boolean> = streamsCancel.asFlux().next()
+
+    /**
+     * Register a callback invoked during phase 1: stop accepting new connections / requests.
+     * Each hook is invoked after the load-balancer-grace period.
+     */
+    fun registerStopAccepting(name: String, hook: () -> Unit) {
+        stopAcceptingHooks.add(ShutdownHook(name, hook))
+    }
+
+    /**
+     * Register a callback invoked during phase 2: force-close servers after drain.
+     */
+    fun registerForceClose(name: String, hook: () -> Unit) {
+        forceCloseHooks.add(ShutdownHook(name, hook))
+    }
+
+    fun beginRequest() {
+        inFlight.incrementAndGet()
+    }
+
+    fun endRequest() {
+        inFlight.decrementAndGet()
+    }
+
+    /** Wraps a Mono so the call is counted as in-flight while it executes. */
+    fun <T> trackMono(source: Mono<T>): Mono<T> {
+        return Mono.using(
+            { beginRequest(); TRACK_TOKEN },
+            { _ -> source },
+            { _ -> endRequest() },
+            true,
+        )
+    }
+
+    /** Wraps a Flux so the call is counted as in-flight while it executes. */
+    fun <T> trackFlux(source: Flux<T>): Flux<T> {
+        return Flux.using(
+            { beginRequest(); TRACK_TOKEN },
+            { _ -> source },
+            { _ -> endRequest() },
+            true,
+        )
+    }
+
+    private fun awaitDrain(timeoutMillis: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (inFlight.get() > 0 && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(100)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return false
+            }
+        }
+        return inFlight.get() == 0
+    }
+
+    override fun onApplicationEvent(event: ContextClosedEvent) {
+        if (!shuttingDown.compareAndSet(false, true)) {
+            return
+        }
+        log.info("Graceful shutdown initiated")
+
+        // Phase 1a: mark unhealthy + wait for the load balancer to drain traffic.
+        log.info(
+            "[shutdown 1/4] Marking service unhealthy; waiting {}s for load balancer to drain inbound traffic",
+            healthGraceSeconds,
+        )
+        sleepQuietly(healthGraceSeconds * 1000)
+
+        // Phase 1b: stop accepting new requests on inbound servers.
+        log.info("[shutdown 2/4] Stop accepting new connections on inbound servers")
+        runHooks(stopAcceptingHooks)
+
+        // Phase 1c: tell long-running streams to wrap up.
+        log.info("[shutdown 3/4] Signaling long-running streams to complete (in-flight={})", inFlight.get())
+        streamsCancel.tryEmitNext(true)
+
+        // Phase 2: wait for short-lived calls to finish.
+        val drained = awaitDrain(drainTimeoutSeconds * 1000)
+        drainComplete.set(true)
+        if (drained) {
+            log.info("All in-flight requests completed within drain window")
+        } else {
+            log.warn(
+                "Drain timeout reached after {}s; {} request(s) still in flight",
+                drainTimeoutSeconds,
+                inFlight.get(),
+            )
+        }
+
+        // Phase 3: force-close inbound servers (cancels any still-pending streams).
+        log.info("[shutdown 4/4] Force-closing inbound servers")
+        runHooks(forceCloseHooks)
+
+        log.info("Graceful shutdown coordinator finished; handing off to bean destruction")
+    }
+
+    private fun runHooks(hooks: List<ShutdownHook>) {
+        hooks.forEach { hook ->
+            try {
+                hook.action()
+            } catch (t: Throwable) {
+                log.warn("Shutdown hook '${hook.name}' failed: ${t.javaClass.simpleName}: ${t.message}")
+            }
+        }
+    }
+
+    private fun sleepQuietly(millis: Long) {
+        if (millis <= 0) return
+        try {
+            Thread.sleep(millis)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    // Listener should run before standard bean-destruction lifecycle.
+    override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE
+
+    private data class ShutdownHook(val name: String, val action: () -> Unit)
+}

--- a/src/main/kotlin/io/emeraldpay/dshackle/GrpcServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GrpcServer.kt
@@ -150,6 +150,6 @@ open class GrpcServer(
             srv.shutdownNow()
             srv.awaitTermination(5, TimeUnit.SECONDS)
         }
-        log.info("GRPC Server shot down")
+        log.info("GRPC Server shut down")
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/GrpcServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/GrpcServer.kt
@@ -46,6 +46,7 @@ open class GrpcServer(
     private val accessHandler: AccessHandlerGrpc,
     private val grpcServerBraveInterceptor: ServerInterceptor,
     private val authInterceptor: AuthInterceptor,
+    private val gracefulShutdown: GracefulShutdown,
 ) {
     @Value("\${spring.application.max-metadata-size}")
     private var maxMetadataSize: Int = Defaults.maxMetadataSize
@@ -119,13 +120,36 @@ open class GrpcServer(
 
         server.start()
         log.info("GRPC Server started")
+
+        gracefulShutdown.registerStopAccepting("grpc-server") {
+            log.info("gRPC: refusing new calls (server.shutdown)")
+            server.shutdown()
+        }
+        gracefulShutdown.registerForceClose("grpc-server") {
+            val drainSeconds = gracefulShutdown.drainTimeoutSeconds()
+            if (!server.isTerminated) {
+                if (!server.awaitTermination(drainSeconds, TimeUnit.SECONDS)) {
+                    log.warn("gRPC: draining did not complete in {}s, forcing shutdownNow", drainSeconds)
+                    server.shutdownNow()
+                    server.awaitTermination(gracefulShutdown.forceTimeoutSeconds(), TimeUnit.SECONDS)
+                }
+                log.info("gRPC Server stopped")
+            }
+        }
     }
 
     @PreDestroy
     fun stop() {
-        log.info("Shutting down GRPC Server...")
-        server?.shutdown()
-        server?.awaitTermination(10, TimeUnit.SECONDS)
+        val srv = server ?: return
+        if (srv.isTerminated) {
+            return
+        }
+        log.info("Shutting down GRPC Server (fallback)...")
+        srv.shutdown()
+        if (!srv.awaitTermination(10, TimeUnit.SECONDS)) {
+            srv.shutdownNow()
+            srv.awaitTermination(5, TimeUnit.SECONDS)
+        }
         log.info("GRPC Server shot down")
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/ProxyStarter.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/ProxyStarter.kt
@@ -24,6 +24,7 @@ import io.emeraldpay.dshackle.proxy.WriteRpcJson
 import io.emeraldpay.dshackle.rpc.NativeCall
 import io.emeraldpay.dshackle.rpc.NativeSubscribe
 import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -39,11 +40,14 @@ class ProxyStarter(
     private val nativeSubscribe: NativeSubscribe,
     private val tlsSetup: TlsSetup,
     private val accessHandlerHttp: AccessHandlerHttp,
+    private val gracefulShutdown: GracefulShutdown,
 ) {
 
     companion object {
         private val log = LoggerFactory.getLogger(ProxyStarter::class.java)
     }
+
+    private var server: ProxyServer? = null
 
     @PostConstruct
     fun start() {
@@ -52,7 +56,14 @@ class ProxyStarter(
             log.debug("Proxy server is not configured")
             return
         }
-        val server = ProxyServer(config, readRpcJson, writeRpcJson, nativeCall, nativeSubscribe, tlsSetup, accessHandlerHttp.factory)
-        server.start()
+        val proxy = ProxyServer(config, readRpcJson, writeRpcJson, nativeCall, nativeSubscribe, tlsSetup, accessHandlerHttp.factory, gracefulShutdown)
+        proxy.start()
+        this.server = proxy
+    }
+
+    @PreDestroy
+    fun stop() {
+        // Fallback in case the GracefulShutdown coordinator did not run.
+        server?.stop()
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/Starter.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/Starter.kt
@@ -64,5 +64,26 @@ fun main(args: Array<String>) {
     val app = SpringApplication(Starter::class.java)
     app.setDefaultProperties(ResourcePropertySource("version.properties").source)
     app.setBanner(ResourceBanner(ClassPathResource("banner.txt")))
-    app.run(*args)
+    // We register our own JVM shutdown hook below to drive the graceful sequence
+    // synchronously; disable Spring's default hook to avoid racing bean destruction
+    // with the in-flight drain.
+    app.setRegisterShutdownHook(false)
+
+    val context = app.run(*args)
+
+    val shutdownHook = Thread({
+        try {
+            val graceful = context.getBean(GracefulShutdown::class.java)
+            graceful.triggerShutdown()
+        } catch (t: Throwable) {
+            log.error("Graceful shutdown failed: {}: {}", t.javaClass.simpleName, t.message, t)
+        } finally {
+            try {
+                context.close()
+            } catch (t: Throwable) {
+                log.warn("Application context close failed: {}: {}", t.javaClass.simpleName, t.message)
+            }
+        }
+    }, "graceful-shutdown",)
+    Runtime.getRuntime().addShutdownHook(shutdownHook)
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/HealthCheckSetup.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/HealthCheckSetup.kt
@@ -16,6 +16,7 @@
 package io.emeraldpay.dshackle.monitoring
 
 import com.sun.net.httpserver.HttpServer
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.config.HealthConfig
 import io.emeraldpay.dshackle.upstream.MultistreamHolder
 import jakarta.annotation.PostConstruct
@@ -30,6 +31,7 @@ import java.net.InetSocketAddress
 class HealthCheckSetup(
     private val healthConfig: HealthConfig,
     private val multistreamHolder: MultistreamHolder,
+    private val gracefulShutdown: GracefulShutdown,
 ) {
 
     companion object {
@@ -55,7 +57,9 @@ class HealthCheckSetup(
                 0,
             )
             server.createContext(healthConfig.path) { httpExchange ->
-                val response = if (httpExchange.requestURI.query == "detailed") {
+                val response = if (gracefulShutdown.isShuttingDown()) {
+                    Detailed(false, listOf("SHUTTING DOWN"))
+                } else if (httpExchange.requestURI.query == "detailed") {
                     getDetailedHealth()
                 } else {
                     getHealth()

--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/accesslog/AccessLogWriter.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/accesslog/AccessLogWriter.kt
@@ -18,6 +18,7 @@ package io.emeraldpay.dshackle.monitoring.accesslog
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.config.MainConfig
 import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Repository
@@ -94,6 +95,31 @@ class AccessLogWriter(
             lastErrorAt = now
             m()
         }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        if (!config.enabled) {
+            return
+        }
+        log.info("Flushing access log queue ({} entries pending)", queue.size)
+        scheduler.shutdown()
+        try {
+            scheduler.awaitTermination(2, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+        // Drain any remaining queued events. The runner uses a fixed batch limit,
+        // so loop until the queue is empty.
+        while (queue.isNotEmpty()) {
+            try {
+                flush()
+            } catch (t: Throwable) {
+                log.warn("Failed to flush access log on shutdown: ${t.javaClass.simpleName}: ${t.message}")
+                break
+            }
+        }
+        log.info("Access log flush complete")
     }
 
     protected fun flush() {

--- a/src/main/kotlin/io/emeraldpay/dshackle/monitoring/accesslog/AccessLogWriter.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/monitoring/accesslog/AccessLogWriter.kt
@@ -29,6 +29,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
 @Repository
@@ -51,6 +52,7 @@ class AccessLogWriter(
     private val queue = ConcurrentLinkedQueue<Any>()
     private val objectMapper = Global.objectMapper
     private var lastErrorAt: Instant = Instant.ofEpochMilli(0)
+    private val flushLock = Any()
 
     private val runner = Runnable {
         flushRunner()
@@ -77,7 +79,13 @@ class AccessLogWriter(
                 log.error("Failed to write logs. ${t.javaClass}:${t.message}")
             }
         } finally {
-            scheduler.schedule(runner, FLUSH_SLEEP_MS, TimeUnit.MILLISECONDS)
+            if (!scheduler.isShutdown) {
+                try {
+                    scheduler.schedule(runner, FLUSH_SLEEP_MS, TimeUnit.MILLISECONDS)
+                } catch (e: RejectedExecutionException) {
+                    // Scheduler raced with shutdown(); the @PreDestroy flush will drain the rest.
+                }
+            }
         }
     }
 
@@ -123,30 +131,32 @@ class AccessLogWriter(
     }
 
     protected fun flush() {
-        if (!filename.exists()) {
-            if (!filename.createNewFile()) {
-                logError {
-                    log.error("Cannot create Access Log file at ${filename.absolutePath}")
-                }
-                return
-            }
-        }
-        BufferedOutputStream(FileOutputStream(filename, true)).use { wrt ->
-            var limit = WRITE_BATCH_LIMIT
-            while (limit > 0) {
-                limit -= 1
-                val next = queue.poll() ?: return
-                val bytes: ByteArray? = try {
-                    objectMapper.writeValueAsBytes(next)
-                } catch (t: Throwable) {
+        synchronized(flushLock) {
+            if (!filename.exists()) {
+                if (!filename.createNewFile()) {
                     logError {
-                        log.warn("Failed to write an access log line. ${t.message}")
+                        log.error("Cannot create Access Log file at ${filename.absolutePath}")
                     }
-                    null
+                    return@synchronized
                 }
-                if (bytes != null && bytes.isNotEmpty()) {
-                    wrt.write(bytes)
-                    wrt.write(NL, 0, 1)
+            }
+            BufferedOutputStream(FileOutputStream(filename, true)).use { wrt ->
+                var limit = WRITE_BATCH_LIMIT
+                while (limit > 0) {
+                    limit -= 1
+                    val next = queue.poll() ?: return@synchronized
+                    val bytes: ByteArray? = try {
+                        objectMapper.writeValueAsBytes(next)
+                    } catch (t: Throwable) {
+                        logError {
+                            log.warn("Failed to write an access log line. ${t.message}")
+                        }
+                        null
+                    }
+                    if (bytes != null && bytes.isNotEmpty()) {
+                        wrt.write(bytes)
+                        wrt.write(NL, 0, 1)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
@@ -16,6 +16,7 @@
 package io.emeraldpay.dshackle.proxy
 
 import io.emeraldpay.dshackle.Chain
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
@@ -24,6 +25,7 @@ import io.emeraldpay.dshackle.upstream.ChainResponse
 import io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcException
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
+import io.netty.handler.codec.http.HttpResponseStatus
 import org.apache.hc.core5.http.HttpHeaders
 import org.reactivestreams.Publisher
 import org.slf4j.LoggerFactory
@@ -43,6 +45,7 @@ class HttpHandler(
     nativeCall: NativeCall,
     private val accessHandler: AccessHandlerHttp.HandlerFactory,
     private val requestMetrics: ProxyServer.RequestMetricsFactory,
+    private val gracefulShutdown: GracefulShutdown,
 ) : BaseHandler(writeRpcJson, nativeCall, requestMetrics) {
 
     companion object {
@@ -64,17 +67,28 @@ class HttpHandler(
 
     fun proxy(routeConfig: ProxyConfig.Route): BiFunction<HttpServerRequest, HttpServerResponse, Publisher<Void>> {
         return BiFunction { req, resp ->
-            // handle access events
-            val eventHandler = accessHandler.create(req, routeConfig.blockchain)
-            val request = req.receive()
-                .aggregate()
-                .asByteArray()
-            val results = processRequest(routeConfig.blockchain, request, eventHandler)
-                // make sure that the access log handler is closed at the end, so it can render the logs
-                .doFinally { eventHandler.close() }
-            addCorsHeadersIfSet(resp)
-                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .send(results)
+            if (gracefulShutdown.isShuttingDown()) {
+                // Reject new traffic during graceful shutdown so the load balancer
+                // routes the request to a healthy instance.
+                addCorsHeadersIfSet(resp)
+                    .status(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                    .addHeader(HttpHeaders.CONNECTION, "close")
+                    .send()
+            } else {
+                // handle access events
+                val eventHandler = accessHandler.create(req, routeConfig.blockchain)
+                val request = req.receive()
+                    .aggregate()
+                    .asByteArray()
+                val results = gracefulShutdown.trackFlux(
+                    processRequest(routeConfig.blockchain, request, eventHandler)
+                        // make sure that the access log handler is closed at the end, so it can render the logs
+                        .doFinally { eventHandler.close() },
+                )
+                addCorsHeadersIfSet(resp)
+                    .addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                    .send(results)
+            }
         }
     }
 

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
@@ -16,8 +16,8 @@
 package io.emeraldpay.dshackle.proxy
 
 import io.emeraldpay.dshackle.Chain
-import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
 import io.emeraldpay.dshackle.rpc.NativeCall

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
@@ -17,6 +17,7 @@
 package io.emeraldpay.dshackle.proxy
 
 import io.emeraldpay.dshackle.Chain
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.TlsSetup
 import io.emeraldpay.dshackle.config.ProxyConfig
@@ -31,8 +32,10 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.MultiThreadIoEventLoopGroup
 import io.netty.channel.nio.NioIoHandler
 import org.slf4j.LoggerFactory
+import reactor.netty.DisposableServer
 import reactor.netty.http.server.HttpServer
 import reactor.netty.http.server.HttpServerRoutes
+import java.time.Duration
 import java.util.EnumMap
 import java.util.concurrent.ConcurrentHashMap
 
@@ -47,6 +50,7 @@ class ProxyServer(
     nativeSubscribe: NativeSubscribe,
     private val tlsSetup: TlsSetup,
     accessHandler: AccessHandlerHttp.HandlerFactory,
+    private val gracefulShutdown: GracefulShutdown,
 ) {
 
     companion object {
@@ -80,12 +84,15 @@ class ProxyServer(
         StandardRequestMetrics()
     }
 
-    private val httpHandler = HttpHandler(config, readRpcJson, writeRpcJson, nativeCall, accessHandler, requestMetrics)
+    private val httpHandler = HttpHandler(config, readRpcJson, writeRpcJson, nativeCall, accessHandler, requestMetrics, gracefulShutdown)
     private val wsHandler: WebsocketHandler? = if (config.websocketEnabled) {
-        WebsocketHandler(readRpcJson, writeRpcJson, nativeCall, nativeSubscribe, accessHandler, requestMetrics)
+        WebsocketHandler(readRpcJson, writeRpcJson, nativeCall, nativeSubscribe, accessHandler, requestMetrics, gracefulShutdown)
     } else {
         null
     }
+
+    @Volatile
+    private var disposableServer: DisposableServer? = null
 
     fun start() {
         if (!config.enabled) {
@@ -107,10 +114,32 @@ class ProxyServer(
             serverBuilder = serverBuilder.secure { secure -> secure.sslContext(sslContext) }
         }
 
-        serverBuilder
+        val server = serverBuilder
             .route(this::setupRoutes)
             .runOn(MultiThreadIoEventLoopGroup(NioIoHandler.newFactory()))
             .bindNow()
+        this.disposableServer = server
+
+        gracefulShutdown.registerForceClose("http-proxy-server") {
+            stop()
+        }
+    }
+
+    /**
+     * Gracefully stops the HTTP proxy server. Closes the listening socket and existing
+     * connections; waits up to [GracefulShutdown.forceTimeoutSeconds] for the server
+     * to fully release resources.
+     */
+    fun stop() {
+        val server = disposableServer ?: return
+        if (server.isDisposed) return
+        log.info("Shutting down HTTP/WS proxy server")
+        try {
+            server.disposeNow(Duration.ofSeconds(gracefulShutdown.forceTimeoutSeconds()))
+        } catch (t: Throwable) {
+            log.warn("HTTP/WS proxy server did not stop cleanly: ${t.javaClass.simpleName}: ${t.message}")
+        }
+        log.info("HTTP/WS proxy server stopped")
     }
 
     fun setupRoutes(routes: HttpServerRoutes) {

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
@@ -17,8 +17,8 @@
 package io.emeraldpay.dshackle.proxy
 
 import io.emeraldpay.dshackle.Chain
-import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.TlsSetup
 import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
@@ -94,6 +94,9 @@ class ProxyServer(
     @Volatile
     private var disposableServer: DisposableServer? = null
 
+    @Volatile
+    private var eventLoopGroup: MultiThreadIoEventLoopGroup? = null
+
     fun start() {
         if (!config.enabled) {
             log.debug("Proxy server is not enabled")
@@ -114,30 +117,65 @@ class ProxyServer(
             serverBuilder = serverBuilder.secure { secure -> secure.sslContext(sslContext) }
         }
 
+        val loopGroup = MultiThreadIoEventLoopGroup(NioIoHandler.newFactory())
+        this.eventLoopGroup = loopGroup
         val server = serverBuilder
             .route(this::setupRoutes)
-            .runOn(MultiThreadIoEventLoopGroup(NioIoHandler.newFactory()))
+            .runOn(loopGroup)
             .bindNow()
         this.disposableServer = server
 
+        // Phase 1: stop accepting new connections by closing the server (listening) channel.
+        // Existing accepted child channels remain in the worker group and continue to serve
+        // their in-flight requests until the drain phase finishes.
+        gracefulShutdown.registerStopAccepting("http-proxy-server") {
+            stopAcceptingConnections()
+        }
+        // Phase 2: dispose remaining channels and shut down the worker event loop group.
         gracefulShutdown.registerForceClose("http-proxy-server") {
             stop()
         }
     }
 
     /**
-     * Gracefully stops the HTTP proxy server. Closes the listening socket and existing
-     * connections; waits up to [GracefulShutdown.forceTimeoutSeconds] for the server
-     * to fully release resources.
+     * Closes the listening socket so no new connections are accepted, but leaves existing
+     * connections alive so in-flight requests can finish during the drain phase.
      */
-    fun stop() {
+    fun stopAcceptingConnections() {
         val server = disposableServer ?: return
         if (server.isDisposed) return
-        log.info("Shutting down HTTP/WS proxy server")
         try {
-            server.disposeNow(Duration.ofSeconds(gracefulShutdown.forceTimeoutSeconds()))
+            log.info("HTTP/WS proxy: closing listening socket")
+            server.channel().close().await(gracefulShutdown.forceTimeoutSeconds(), java.util.concurrent.TimeUnit.SECONDS)
         } catch (t: Throwable) {
-            log.warn("HTTP/WS proxy server did not stop cleanly: ${t.javaClass.simpleName}: ${t.message}")
+            log.warn("HTTP/WS proxy: failed to close listening socket: ${t.javaClass.simpleName}: ${t.message}")
+        }
+    }
+
+    /**
+     * Gracefully stops the HTTP proxy server. Closes the listening socket and existing
+     * connections; waits up to [GracefulShutdown.forceTimeoutSeconds] for the server
+     * to fully release resources, then shuts down the worker event loop group.
+     */
+    fun stop() {
+        val timeout = Duration.ofSeconds(gracefulShutdown.forceTimeoutSeconds())
+        val server = disposableServer
+        if (server != null && !server.isDisposed) {
+            log.info("Shutting down HTTP/WS proxy server")
+            try {
+                server.disposeNow(timeout)
+            } catch (t: Throwable) {
+                log.warn("HTTP/WS proxy server did not stop cleanly: ${t.javaClass.simpleName}: ${t.message}")
+            }
+        }
+        eventLoopGroup?.let { group ->
+            try {
+                group.shutdownGracefully(0, gracefulShutdown.forceTimeoutSeconds(), java.util.concurrent.TimeUnit.SECONDS)
+                    .await(gracefulShutdown.forceTimeoutSeconds(), java.util.concurrent.TimeUnit.SECONDS)
+            } catch (t: Throwable) {
+                log.warn("HTTP/WS proxy event loop group did not stop cleanly: ${t.javaClass.simpleName}: ${t.message}")
+            }
+            eventLoopGroup = null
         }
         log.info("HTTP/WS proxy server stopped")
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
@@ -18,8 +18,8 @@ package io.emeraldpay.dshackle.proxy
 import com.google.protobuf.ByteString
 import io.emeraldpay.api.proto.BlockchainOuterClass
 import io.emeraldpay.dshackle.Chain
-import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
 import io.emeraldpay.dshackle.rpc.NativeCall
@@ -189,6 +189,17 @@ class WebsocketHandler(
                     .map { Global.objectMapper.writeValueAsString(it) }
                     .doOnNext { eventHandler.onResponse(NativeCall.CallResult.ok(0, null, it.toByteArray(), null, emptyList(), null)) }
                     .doFinally { eventHandler.close() }
+            } else if (gracefulShutdown.isShuttingDown()) {
+                // Mirror the HTTP-side behavior: reject new RPC calls during shutdown so the
+                // load balancer routes them to a healthy instance.
+                val response = ResponseJson<Any, Any>().also {
+                    it.id = call.id
+                    it.error = io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError(
+                        io.emeraldpay.dshackle.upstream.ethereum.rpc.RpcResponseError.CODE_INTERNAL_ERROR,
+                        "service is shutting down",
+                    )
+                }
+                Mono.just(Global.objectMapper.writeValueAsString(response))
             } else {
                 val eventHandler: AccessHandlerHttp.RequestHandler = eventHandlerFactory.call()
                 val proxyCall = readRpcJson.convertToNativeCall(ProxyCall.RpcType.SINGLE, listOf(call))

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/WebsocketHandler.kt
@@ -18,6 +18,7 @@ package io.emeraldpay.dshackle.proxy
 import com.google.protobuf.ByteString
 import io.emeraldpay.api.proto.BlockchainOuterClass
 import io.emeraldpay.dshackle.Chain
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.emeraldpay.dshackle.Global
 import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
@@ -46,6 +47,7 @@ class WebsocketHandler(
     private val nativeSubscribe: NativeSubscribe,
     private val accessHandler: AccessHandlerHttp.HandlerFactory,
     private val requestMetrics: ProxyServer.RequestMetricsFactory,
+    private val gracefulShutdown: GracefulShutdown,
 ) : BaseHandler(writeRpcJson, nativeCall, requestMetrics) {
 
     companion object {
@@ -147,6 +149,8 @@ class WebsocketHandler(
                             WsSubscriptionResponse(params = WsSubscriptionData(data, subscriptionId))
                         }
                         .takeUntilOther(currentControl.asMono())
+                        // graceful-shutdown: cancel the subscription stream when the service starts shutting down
+                        .takeUntilOther(gracefulShutdown.streamsCancelSignal())
                     Flux.concat(Mono.just(start), responses)
                         .map { Global.objectMapper.writeValueAsString(it) }
                         .doOnNext {
@@ -188,10 +192,12 @@ class WebsocketHandler(
             } else {
                 val eventHandler: AccessHandlerHttp.RequestHandler = eventHandlerFactory.call()
                 val proxyCall = readRpcJson.convertToNativeCall(ProxyCall.RpcType.SINGLE, listOf(call))
-                Mono.from(execute(blockchain, proxyCall, eventHandler))
-                    // thought the event handler is used in execute
-                    // it still needs to be closed at the end, so it can render the logs
-                    .doFinally { eventHandler.close() }
+                gracefulShutdown.trackMono(
+                    Mono.from(execute(blockchain, proxyCall, eventHandler))
+                        // thought the event handler is used in execute
+                        // it still needs to be closed at the end, so it can render the logs
+                        .doFinally { eventHandler.close() },
+                )
             }
         }
     }

--- a/src/main/kotlin/io/emeraldpay/dshackle/rpc/BlockchainRpc.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/rpc/BlockchainRpc.kt
@@ -21,6 +21,7 @@ import io.emeraldpay.api.proto.Common
 import io.emeraldpay.api.proto.ReactorBlockchainGrpc
 import io.emeraldpay.dshackle.Chain
 import io.emeraldpay.dshackle.ChainValue
+import io.emeraldpay.dshackle.GracefulShutdown
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
@@ -47,6 +48,7 @@ class BlockchainRpc(
     @param:Qualifier("rpcScheduler")
     private val scheduler: Scheduler,
     private val subscribeChainStatus: SubscribeChainStatus,
+    private val gracefulShutdown: GracefulShutdown,
 ) : ReactorBlockchainGrpc.BlockchainImplBase() {
 
     private val log = LoggerFactory.getLogger(BlockchainRpc::class.java)
@@ -68,7 +70,7 @@ class BlockchainRpc(
         var startTime = 0L
         var metrics: RequestMetrics? = null
         val idsMap = mutableMapOf<Int, String>()
-        return nativeCall.nativeCall(
+        val source = nativeCall.nativeCall(
             request
                 .subscribeOn(scheduler)
                 .doOnNext { req ->
@@ -95,6 +97,7 @@ class BlockchainRpc(
         }.doOnError {
             failMetric.increment()
         }
+        return gracefulShutdown.trackFlux(source)
     }
 
     override fun nativeSubscribe(request: Mono<BlockchainOuterClass.NativeSubscribeRequest>): Flux<BlockchainOuterClass.NativeSubscribeReplyItem> {
@@ -119,6 +122,8 @@ class BlockchainRpc(
                     log.info("Error ${t.message} in subscription ${req.subscriptionId}")
                     failMetric.increment()
                 }
+                    // graceful-shutdown: terminate stream when service is shutting down
+                    .takeUntilOther(gracefulShutdown.streamsCancelSignal())
             }
     }
 
@@ -127,6 +132,7 @@ class BlockchainRpc(
             request
                 .doOnNext { chainMetrics.get(it.type).subscribeHeadMetric.increment() },
         ).doOnError { failMetric.increment() }
+            .takeUntilOther(gracefulShutdown.streamsCancelSignal())
     }
 
     override fun describe(request: Mono<BlockchainOuterClass.DescribeRequest>): Mono<BlockchainOuterClass.DescribeResponse> {
@@ -139,6 +145,7 @@ class BlockchainRpc(
         subscribeStatusMetric.increment()
         return subscribeStatus.subscribeStatus(request)
             .doOnError { failMetric.increment() }
+            .takeUntilOther(gracefulShutdown.streamsCancelSignal())
     }
 
     override fun subscribeNodeStatus(request: Mono<BlockchainOuterClass.SubscribeNodeStatusRequest>): Flux<BlockchainOuterClass.NodeStatusResponse> {
@@ -152,13 +159,14 @@ class BlockchainRpc(
                 .doFinally { sig ->
                     log.info("Closing node status subscription named [$subId] with $sig")
                 }
-        }
+        }.takeUntilOther(gracefulShutdown.streamsCancelSignal())
     }
 
     override fun subscribeChainStatus(
         request: Mono<BlockchainOuterClass.SubscribeChainStatusRequest>,
     ): Flux<BlockchainOuterClass.SubscribeChainStatusResponse> {
         return subscribeChainStatus.chainStatuses()
+            .takeUntilOther(gracefulShutdown.streamsCancelSignal())
     }
 
     class RequestMetrics(val chain: Chain) {

--- a/src/test/groovy/io/emeraldpay/dshackle/monitoring/HealthCheckSetupSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/monitoring/HealthCheckSetupSpec.groovy
@@ -34,7 +34,7 @@ class HealthCheckSetupSpec extends Specification {
         def up1 = Mock(Upstream)
         def ethereumUpstreams = Mock(Multistream)
         def multistream = Mock(MultistreamHolder)
-        def check = new HealthCheckSetup(config, multistream)
+        def check = new HealthCheckSetup(config, multistream, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L))
 
         when:
         def act = check.health
@@ -58,7 +58,7 @@ class HealthCheckSetupSpec extends Specification {
         def up1 = Mock(Upstream)
         def bitcoinUpstreams = Mock(Multistream)
         def multistream = Mock(MultistreamHolder)
-        def check = new HealthCheckSetup(config, multistream)
+        def check = new HealthCheckSetup(config, multistream, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L))
 
         when:
         def act = check.health
@@ -84,7 +84,7 @@ class HealthCheckSetupSpec extends Specification {
         def up3 = Mock(Upstream)
         def ethereumUpstreams = Mock(Multistream)
         def multistream = Mock(MultistreamHolder)
-        def check = new HealthCheckSetup(config, multistream)
+        def check = new HealthCheckSetup(config, multistream, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L))
 
         when:
         def act = check.health
@@ -112,7 +112,7 @@ class HealthCheckSetupSpec extends Specification {
         def up3 = Mock(Upstream)
         def ethereumUpstreams = Mock(Multistream)
         def multistream = Mock(MultistreamHolder)
-        def check = new HealthCheckSetup(config, multistream)
+        def check = new HealthCheckSetup(config, multistream, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L))
 
         when:
         def act = check.health
@@ -140,7 +140,7 @@ class HealthCheckSetupSpec extends Specification {
         def up3 = Mock(Upstream)
         def ethereumUpstreams = Mock(Multistream)
         def multistream = Mock(MultistreamHolder)
-        def check = new HealthCheckSetup(config, multistream)
+        def check = new HealthCheckSetup(config, multistream, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L))
 
         when:
         def act = check.detailedHealth

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
@@ -58,7 +58,8 @@ class HttpHandlerSpec extends Specification {
         def handler = new HttpHandler(
                 new ProxyConfig(),
                 new ReadRpcJson(), new WriteRpcJson(),
-                nativeCall, accessHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                nativeCall, accessHandlerFactory, Stub(ProxyServer.RequestMetricsFactory),
+                new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         when:
@@ -88,7 +89,7 @@ class HttpHandlerSpec extends Specification {
                 new ProxyConfig(),
                 read, new WriteRpcJson(),
                 Stub(NativeCall), Stub(AccessHandlerHttp.HandlerFactory),
-                metrics
+                metrics, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
 
@@ -114,7 +115,8 @@ class HttpHandlerSpec extends Specification {
         def handler = new HttpHandler(
                 new ProxyConfig(),
                 new ReadRpcJson(), writeRpcJson,
-                nativeCall, Stub(AccessHandlerHttp.HandlerFactory), Stub(ProxyServer.RequestMetricsFactory)
+                nativeCall, Stub(AccessHandlerHttp.HandlerFactory), Stub(ProxyServer.RequestMetricsFactory),
+                new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def call = new ProxyCall(ProxyCall.RpcType.SINGLE)

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/ProxyServerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/ProxyServerSpec.groovy
@@ -22,7 +22,7 @@ class ProxyServerSpec extends Specification {
                 config1,
                 new ReadRpcJson(), new WriteRpcJson(),
                 Stub(NativeCall), Stub(NativeSubscribe),
-                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory()
+                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory(), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def routes = Mock(HttpServerRoutes)
@@ -46,7 +46,7 @@ class ProxyServerSpec extends Specification {
                 config1,
                 new ReadRpcJson(), new WriteRpcJson(),
                 Stub(NativeCall), Stub(NativeSubscribe),
-                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory()
+                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory(), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def routes = Mock(HttpServerRoutes)
@@ -66,7 +66,7 @@ class ProxyServerSpec extends Specification {
                 config1,
                 new ReadRpcJson(), new WriteRpcJson(),
                 Stub(NativeCall), Stub(NativeSubscribe),
-                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory()
+                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory(), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
         def act = proxyServer.connectAddress("http")
@@ -83,7 +83,7 @@ class ProxyServerSpec extends Specification {
                 config1,
                 new ReadRpcJson(), new WriteRpcJson(),
                 Stub(NativeCall), Stub(NativeSubscribe),
-                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory()
+                Stub(TlsSetup), new AccessHandlerHttp.NoOpFactory(), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
         def act = proxyServer.connectAddress("ws")

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/WebsocketHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/WebsocketHandlerSpec.groovy
@@ -37,7 +37,7 @@ class WebsocketHandlerSpec extends Specification {
     def "Parse standard RPC request"() {
         setup:
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
         def act = handler.parseRequest('{"id": 5, "jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["0x100001", false]}'.bytes, Chain.ETHEREUM__MAINNET)
@@ -60,7 +60,7 @@ class WebsocketHandlerSpec extends Specification {
             }
         }
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, metrics
+                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, metrics, new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
         def act = handler.parseRequest('hello world'.bytes, Chain.ETHEREUM__MAINNET)
@@ -74,7 +74,7 @@ class WebsocketHandlerSpec extends Specification {
         setup:
         def req1 = '{"id": 5, "jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["0x100001", false]}'
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), Stub(WriteRpcJson), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
         when:
         def act = handler.parseRequest("[$req1]".bytes, Chain.ETHEREUM__MAINNET)
@@ -92,7 +92,7 @@ class WebsocketHandlerSpec extends Specification {
             1 * it.nativeCallResult(_) >> Flux.fromIterable([response])
         }
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), new WriteRpcJson(), nativeCall, Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), new WriteRpcJson(), nativeCall, Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def request = new RequestJson("foo_test", [], 2)
@@ -113,7 +113,7 @@ class WebsocketHandlerSpec extends Specification {
             1 * it.subscribe(Chain.ETHEREUM__MAINNET, "foo_test", null, Selector.empty) >> Flux.fromIterable([response1, response2])
         }
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), nativeSubscribe, requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), nativeSubscribe, requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def request = new RequestJson("eth_subscribe", ["foo_test"], 2)
@@ -132,7 +132,7 @@ class WebsocketHandlerSpec extends Specification {
         setup:
 
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def control = new HashMap<String, Sinks.One<Boolean>>()
@@ -153,7 +153,7 @@ class WebsocketHandlerSpec extends Specification {
         setup:
 
         def handler = new WebsocketHandler(
-                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
+                new ReadRpcJson(), new WriteRpcJson(), Stub(NativeCall), Stub(NativeSubscribe), requestHandlerFactory, Stub(ProxyServer.RequestMetricsFactory), new io.emeraldpay.dshackle.GracefulShutdown(0L, 0L, 0L)
         )
 
         def control = new HashMap<String, Sinks.One<Boolean>>()


### PR DESCRIPTION
## Summary
This PR implements a comprehensive graceful shutdown mechanism that coordinates the orderly termination of the Dshackle service, following industry-standard load-balancer-friendly patterns. The implementation ensures in-flight requests complete cleanly, long-running streams terminate gracefully, and resources are properly released before the application exits.

## Key Changes

- **New `GracefulShutdown` service**: A Spring-managed coordinator that orchestrates a 4-phase shutdown sequence:
  1. Mark service unhealthy and wait for load balancer to drain traffic
  2. Stop accepting new connections on inbound servers (gRPC, HTTP/WS)
  3. Signal long-running streams to terminate gracefully
  4. Force-close remaining servers after a configurable drain timeout
  
  Provides configurable timeouts via properties: `dshackle.shutdown.health-grace-seconds`, `dshackle.shutdown.drain-timeout-seconds`, and `dshackle.shutdown.force-timeout-seconds`

- **Request tracking**: Added `trackMono()` and `trackFlux()` methods to count in-flight requests, enabling the coordinator to wait for active calls to complete before forcing shutdown

- **HTTP/WS proxy integration**:
  - Reject new requests with 503 Service Unavailable during shutdown
  - Track all proxy requests as in-flight
  - Register shutdown hooks to gracefully stop the HTTP server
  - Added `ProxyServer.stop()` method to cleanly dispose the Netty server

- **gRPC server integration**:
  - Register hooks to refuse new calls and await graceful termination
  - Fallback to `shutdownNow()` if drain timeout is exceeded
  - Enhanced `@PreDestroy` cleanup as a safety net

- **WebSocket subscription handling**: Long-running subscriptions now listen to `streamsCancelSignal()` and terminate cleanly when shutdown begins

- **gRPC BlockchainRpc**: Track all native call requests as in-flight to ensure they complete before shutdown

- **Health check endpoint**: Integrated with graceful shutdown to reject requests during shutdown

- **Access log flushing**: Added `@PreDestroy` method to flush remaining queued log entries during shutdown

- **ProxyStarter**: Added fallback `@PreDestroy` to ensure proxy server stops even if graceful shutdown coordinator doesn't run

## Implementation Details

- Uses `AtomicBoolean` and `AtomicInteger` for thread-safe shutdown state and in-flight request counting
- Implements `ApplicationListener<ContextClosedEvent>` with `HIGHEST_PRECEDENCE` to run before standard bean destruction
- Uses Reactor's `Sinks.replay()` for the streams cancel signal so late subscribers still receive the shutdown notification
- Graceful shutdown hooks are registered by servers during startup and executed during the shutdown sequence
- All timeouts are configurable and logged for observability
- Comprehensive error handling ensures one failing hook doesn't prevent others from executing

https://claude.ai/code/session_01NuLxxbuTAUyXcSg5ghN8PT